### PR TITLE
do not recreate components if they already exist

### DIFF
--- a/bepinex_dev/SPTQuestingBots/Components/LocationData.cs
+++ b/bepinex_dev/SPTQuestingBots/Components/LocationData.cs
@@ -44,25 +44,25 @@ namespace SPTQuestingBots.Components
 
             UpdateMaxTotalBots();
 
-            Singleton<GameWorld>.Instance.gameObject.AddComponent<BotLogic.HiveMind.BotHiveMindMonitor>();
+            Singleton<GameWorld>.Instance.gameObject.GetOrAddComponent<BotLogic.HiveMind.BotHiveMindMonitor>();
 
             if (ConfigController.Config.Questing.Enabled)
             {
                 QuestHelpers.ClearCache();
-                Singleton<GameWorld>.Instance.gameObject.AddComponent<BotQuestBuilder>();
-                Singleton<GameWorld>.Instance.gameObject.AddComponent<DebugData>();
+                Singleton<GameWorld>.Instance.gameObject.GetOrAddComponent<BotQuestBuilder>();
+                Singleton<GameWorld>.Instance.gameObject.GetOrAddComponent<DebugData>();
             }
 
             if (ConfigController.Config.BotSpawns.Enabled)
             {
                 if (ConfigController.Config.BotSpawns.PMCs.Enabled)
                 {
-                    Singleton<GameWorld>.Instance.gameObject.AddComponent<Spawning.PMCGenerator>();
+                    Singleton<GameWorld>.Instance.gameObject.GetOrAddComponent<Spawning.PMCGenerator>();
                 }
 
                 if (ConfigController.Config.BotSpawns.PScavs.Enabled && !CurrentLocation.DisabledForScav)
                 {
-                    Singleton<GameWorld>.Instance.gameObject.AddComponent<Spawning.PScavGenerator>();
+                    Singleton<GameWorld>.Instance.gameObject.GetOrAddComponent<Spawning.PScavGenerator>();
                 }
 
                 BotGenerator.RunBotGenerationTasks();
@@ -70,7 +70,7 @@ namespace SPTQuestingBots.Components
 
             if (ConfigController.Config.Debug.Enabled)
             {
-                Singleton<GameWorld>.Instance.gameObject.AddComponent<PathRender>();
+                Singleton<GameWorld>.Instance.gameObject.GetOrAddComponent<PathRender>();
             }
         }
 

--- a/bepinex_dev/SPTQuestingBots/Patches/AddActivePlayerPatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/AddActivePlayerPatch.cs
@@ -21,13 +21,7 @@ namespace SPTQuestingBots.Patches
         [PatchPostfix]
         private static void PatchPostfix()
         {
-            if (Singleton<GameWorld>.Instance.gameObject.TryGetComponent(out Components.LocationData oldLocationData))
-            {
-                LoggingController.LogInfo("Destroying previous location data...");
-                UnityEngine.GameObject.Destroy(oldLocationData);
-            }
-
-            Singleton<GameWorld>.Instance.gameObject.AddComponent<Components.LocationData>();
+            Singleton<GameWorld>.Instance.gameObject.GetOrAddComponent<Components.LocationData>();
 
             if (ConfigController.Config.BotSpawns.DelayGameStartUntilBotGenFinishes)
             {


### PR DESCRIPTION
Hey Dan, thank you for your work, I'm a huge fan of the mod!

I'm running the mod in a setting where `BotsController.AddActivePLayer` will be called multiple times, but the code doesn't expect that at the moment and throws an error. If you're open to it, I'd like to use `GetOrAddComponent` instead of `AddComponent` in places where you're looking to have only one instance of a component. `AddActivePlayerPatch` then becomes idempotent.

Explanation of the error:
QB's `LocationData` component is created when `BotsController.AddActivePLayer` is called.
We need to call that function several times, which calls the `BotHiveMindMonitor` constructor multiple times, which tries to add the same key to the static `BotHiveMindMonitor.sensors` multiple times.
This patch makes it so we do not create `LocationData` and other components again if they already exist.

Stacktrace of the error:
```
EXCEPTION: System.ArgumentException: An item with the same key has already been added. Key: InCombat
  at System.Collections.Generic.Dictionary`2[TKey,TValue].TryInsert (TKey key, TValue value, System.Collections.Generic.InsertionBehavior behavior) [0x000c1] in <eae584ce26bc40229c1b1aa476bfa589>:0 
  at System.Collections.Generic.Dictionary`2[TKey,TValue].Add (TKey key, TValue value) [0x00000] in <eae584ce26bc40229c1b1aa476bfa589>:0 
  at SPTQuestingBots.BotLogic.HiveMind.BotHiveMindMonitor..ctor () [0x00019] in <fbf3b433c40a4cb485ef1d651ee9eb6b>:0 
2024-04-26 23:38:39.098 +02:00|0.14.1.3.29351|Error|Default|ArgumentException: An item with the same key has already been added. Key: InCombat
System.Collections.Generic.Dictionary`2[TKey,TValue].TryInsert (TKey key, TValue value, System.Collections.Generic.InsertionBehavior behavior) (at <eae584ce26bc40229c1b1aa476bfa589>:0)
System.Collections.Generic.Dictionary`2[TKey,TValue].Add (TKey key, TValue value) (at <eae584ce26bc40229c1b1aa476bfa589>:0)
SPTQuestingBots.BotLogic.HiveMind.BotHiveMindMonitor..ctor () (at <fbf3b433c40a4cb485ef1d651ee9eb6b>:0)
UnityEngine.DebugLogHandler:LogException(Exception, Object)
LogHandler:UnityEngine.ILogHandler.LogException(Exception, Object)
UnityEngine.GameObject:AddComponent()
SPTQuestingBots.Components.LocationData:Awake()
UnityEngine.GameObject:AddComponent()
SPTQuestingBots.Patches.AddActivePlayerPatch:PatchPostfix()
EFT.BotsController:DMD<EFT.BotsController::AddActivePLayer>(BotsController, Player)
UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr)
```