### PR TITLE
feat: blacklist scav island on Shoreline

### DIFF
--- a/bepinex_dev/SPTQuestingBots/Models/QuestObjective.cs
+++ b/bepinex_dev/SPTQuestingBots/Models/QuestObjective.cs
@@ -131,6 +131,11 @@ namespace SPTQuestingBots.Models
             }
         }
 
+        public IEnumerable<Vector3?> GetAllPositions()
+        {
+            return questObjectiveSteps.Select(step => step.GetPosition());
+        }
+
         public bool TrySnapAllStepPositionsToNavMesh()
         {
             bool allSnapped = true;
@@ -160,7 +165,7 @@ namespace SPTQuestingBots.Models
                     LoggingController.LogError("Unable to find switch \"" + step.SwitchID + "\" for quest objective " + ToString());
                 }
             }
-            
+
             return allFound;
         }
 


### PR DESCRIPTION
Refs: #18

This is supposed to blacklist any quest that has at least one position in this zone:
![image](https://github.com/dwesterwick/SPTQuestingBots/assets/17963791/6e00c423-e3e9-48a1-8a6c-8fb41605aadc)

I do not have decompiled tarkov and all the import references so I cannot check that this builds, but it's supposed to)

Also, this is only doing `GetFirstStepPosition` on Lighthouse, not on every objective