### PR TITLE
Fixes for Unlocking Doors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ bepinex_dev/SPTQuestingBots/.vs
 bepinex_dev/SPTQuestingBots/packages
 bepinex_dev/SPTQuestingBots/bin
 bepinex_dev/SPTQuestingBots/obj
+bepinex_dev/SPTQuestingBots-InteropTest/.vs
+bepinex_dev/SPTQuestingBots-InteropTest/packages
+bepinex_dev/SPTQuestingBots-InteropTest/bin
+bepinex_dev/SPTQuestingBots-InteropTest/obj

--- a/bepinex_dev/SPTQuestingBots/BotLogic/Objective/UnlockDoorAction.cs
+++ b/bepinex_dev/SPTQuestingBots/BotLogic/Objective/UnlockDoorAction.cs
@@ -114,8 +114,21 @@ namespace SPTQuestingBots.BotLogic.Objective
                 return;
             }
 
-            if ((door == null) || !interactionPosition.HasValue)
+            if (door == null)
             {
+                LoggingController.LogError("Door" + door.Id + " no longer exists");
+
+                ObjectiveManager.FailObjective();
+
+                return;
+            }
+
+            if (!interactionPosition.HasValue)
+            {
+                LoggingController.LogError(BotOwner.GetText() + " cannot find the appropriate interaction position for door " + door.Id);
+
+                ObjectiveManager.FailObjective();
+
                 return;
             }
 

--- a/bepinex_dev/SPTQuestingBots/Components/LocationData.cs
+++ b/bepinex_dev/SPTQuestingBots/Components/LocationData.cs
@@ -183,12 +183,15 @@ namespace SPTQuestingBots.Components
                 return false;
             }
 
+            // Check if the door is a keycard door
             KeycardDoor keycardDoor = door as KeycardDoor;
             if (keycardDoor != null)
             {
+                // Need to expand the collider because the Saferoom keypad on Interchange isn't fully contained by the NoPowerTip for it
                 float boundsExpansion = 2.5f;
                 Bounds expandedBounds = new Bounds(collider.bounds.center, collider.bounds.size * boundsExpansion);
 
+                // Check if there is a NoPowerTip for any of the keypads for the door (but there should only be one)
                 foreach (InteractiveProxy interactiveProxy in keycardDoor.Proxies)
                 {
                     if (expandedBounds.Contains(interactiveProxy.transform.position))
@@ -201,6 +204,7 @@ namespace SPTQuestingBots.Components
             }
             else
             {
+                // Check if the door has a handle, which is what is needed to test if it's within a NoPowerTip collider
                 Transform doorTestTransform = door.LockHandle?.transform;
                 if (doorTestTransform == null)
                 {
@@ -714,6 +718,7 @@ namespace SPTQuestingBots.Components
                     continue;
                 }
 
+                // Prevent the inner KIBA door from being unlocked before the outer KIBA door
                 if (door.Id == "Shopping_Mall_DesignStuff_00049")
                 {
                     IEnumerable<bool> kibaOuterDoor = areLockedDoorsUnlocked
@@ -727,6 +732,7 @@ namespace SPTQuestingBots.Components
                     }
                 }
 
+                // Prevent doors that require power from being unlocked before the power is turned on
                 if (noPowerTipsForDoors.ContainsKey(door) && noPowerTipsForDoors[door].isActiveAndEnabled)
                 {
                     LoggingController.LogInfo("NoPowerTip for door " + door.Id + " is still active.");
@@ -740,14 +746,9 @@ namespace SPTQuestingBots.Components
                     continue;
                 }
 
-                LoggingController.LogInfo("Actions for door " + door.Id + ": " + string.Join(", ", availableActionsResult.Actions.Select(a => a.Name)));
+                //LoggingController.LogInfo("Actions for door " + door.Id + ": " + string.Join(", ", availableActionsResult.Actions.Select(a => a.Name)));
 
-                /*if (!availableActionsResult.Actions.Any(a => a.Name == "Breach"))
-                {
-                    continue;
-                }*/
-
-                Vector3 ? interactionPosition = GetDoorInteractionPosition(door, startingPosition);
+                Vector3? interactionPosition = GetDoorInteractionPosition(door, startingPosition);
                 if (interactionPosition.HasValue)
                 {
                     return door;

--- a/bepinex_dev/SPTQuestingBots/Helpers/BotPathingHelpers.cs
+++ b/bepinex_dev/SPTQuestingBots/Helpers/BotPathingHelpers.cs
@@ -144,5 +144,17 @@ namespace SPTQuestingBots.Helpers
 
             return true;
         }
+
+        public static bool IsSamePath(this IEnumerable<Vector3> path, IEnumerable<Vector3> other)
+        {
+            if (path.Count() != other.Count())
+            {
+                return false;
+            }
+
+            IEnumerable<bool> areElementsEqual = path.Zip(other, (first, second) => first == second);
+
+            return areElementsEqual.All(e => e == true);
+        }
     }
 }

--- a/bepinex_dev/SPTQuestingBots/Models/BotPathData.cs
+++ b/bepinex_dev/SPTQuestingBots/Models/BotPathData.cs
@@ -152,8 +152,9 @@ namespace SPTQuestingBots.Models
                 }
             }
 
+            // TODO: This needs a lot more testing and optimization before it can be released
             // If the current and proposed paths have already been calculated, do not update the bot's path to avoid getting stuck in infinite loops
-            Vector3[] newCorners = corners.Skip(1).ToArray();
+            /*Vector3[] newCorners = corners.Skip(1).ToArray();
             Vector3[] currentCorners = Corners.Skip(1).ToArray();
 
             if (previousPaths.Any(p => p.IsSamePath(newCorners)))
@@ -172,7 +173,7 @@ namespace SPTQuestingBots.Models
                     //LoggingController.LogInfo("Found new path: " + string.Join(", ", corners.Select(c => c.ToString())));
                     previousPaths.Add(newCorners);
                 }
-            }
+            }*/
             
             SetCorners(corners);
         }

--- a/bepinex_dev/SPTQuestingBots/Models/BotPathData.cs
+++ b/bepinex_dev/SPTQuestingBots/Models/BotPathData.cs
@@ -158,9 +158,10 @@ namespace SPTQuestingBots.Models
 
             if (previousPaths.Any(p => p.IsSamePath(newCorners)))
             {
-                if (ignoreDuplicates && previousPaths.Any(p => p.IsSamePath(currentCorners)))
+                if (ignoreDuplicates && !newCorners.IsSamePath(currentCorners) && previousPaths.Any(p => p.IsSamePath(currentCorners)))
                 {
-                    LoggingController.LogInfo("Ignoring duplicate path: " + string.Join(", ", corners.Select(c => c.ToString())));
+                    LoggingController.LogWarning("Ignoring duplicate path: " + string.Join(", ", corners.Select(c => c.ToString())));
+                    LoggingController.LogWarning("Current path: " + string.Join(", ", Corners.Select(c => c.ToString())));
                     return;
                 }
             }
@@ -168,7 +169,7 @@ namespace SPTQuestingBots.Models
             {
                 if (newCorners.Length > 0)
                 {
-                    LoggingController.LogInfo("Found new path: " + string.Join(", ", corners.Select(c => c.ToString())));
+                    //LoggingController.LogInfo("Found new path: " + string.Join(", ", corners.Select(c => c.ToString())));
                     previousPaths.Add(newCorners);
                 }
             }


### PR DESCRIPTION
Made the following improvements:
* Added null checks in case doors no longer exist (namely because they were destroyed by [Backdoor Bandit](https://hub.sp-tarkov.com/files/file/1154-backdoor-bandit-bb/))
* Added some code to detect when bots are bouncing between two incomplete paths, but it's disabled for now because it's a WIP
* Bug fix for bots unlocking doors requiring power (before it's turned on) when other mods are used that add context-menu actions
* Bug fix for bots unlocking the inner KIBA door before the outer door