### PR TITLE
Update to SPT 3.9.0

### DIFF
--- a/bepinex_dev/SPTQuestingBots-InteropTest/GameStartPatch.cs
+++ b/bepinex_dev/SPTQuestingBots-InteropTest/GameStartPatch.cs
@@ -18,7 +18,7 @@ namespace SPTQuestingBotsInteropTest
         }
 
         [PatchPostfix]
-        private static void PatchPostfix(ref IEnumerator __result, object __instance, float startDelay)
+        private static void PatchPostfix(ref IEnumerator __result, object __instance)
         {
             if (!SPTQuestingBots.QuestingBotsInterop.IsQuestingBotsLoaded())
             {

--- a/bepinex_dev/SPTQuestingBots-InteropTest/GameStartPatch.cs
+++ b/bepinex_dev/SPTQuestingBots-InteropTest/GameStartPatch.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Aki.Reflection.Patching;
+using SPT.Reflection.Patching;
 
 namespace SPTQuestingBotsInteropTest
 {
@@ -13,7 +13,7 @@ namespace SPTQuestingBotsInteropTest
     {
         protected override MethodBase GetTargetMethod()
         {
-            Type localGameType = Aki.Reflection.Utils.PatchConstants.LocalGameType;
+            Type localGameType = SPT.Reflection.Utils.PatchConstants.LocalGameType;
             return localGameType.GetMethod("method_18", BindingFlags.Public | BindingFlags.Instance);
         }
 

--- a/bepinex_dev/SPTQuestingBots-InteropTest/SPTQuestingBots-InteropTest.csproj
+++ b/bepinex_dev/SPTQuestingBots-InteropTest/SPTQuestingBots-InteropTest.csproj
@@ -34,11 +34,11 @@
     <Reference Include="0Harmony">
       <HintPath>..\..\..\..\BepInEx\core\0Harmony.dll</HintPath>
     </Reference>
-    <Reference Include="Aki.Common">
-      <HintPath>..\..\..\..\EscapeFromTarkov_Data\Managed\Aki.Common.dll</HintPath>
+    <Reference Include="spt-common">
+      <HintPath>..\..\..\..\BepInEx\plugins\spt\spt-common.dll</HintPath>
     </Reference>
-    <Reference Include="Aki.Reflection">
-      <HintPath>..\..\..\..\EscapeFromTarkov_Data\Managed\Aki.Reflection.dll</HintPath>
+    <Reference Include="spt-reflection">
+      <HintPath>..\..\..\..\BepInEx\plugins\spt\spt-reflection.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
       <HintPath>..\..\..\..\EscapeFromTarkov_Data\Managed\Assembly-CSharp.dll</HintPath>

--- a/bepinex_dev/SPTQuestingBots/BehaviorExtensions/CustomLogicDelayedUpdate.cs
+++ b/bepinex_dev/SPTQuestingBots/BehaviorExtensions/CustomLogicDelayedUpdate.cs
@@ -26,7 +26,7 @@ namespace SPTQuestingBots.BehaviorExtensions
         private Stopwatch actionElapsedTime = new Stopwatch();
 
         // Find by CreateNode(BotLogicDecision type, BotOwner bot) -> case BotLogicDecision.simplePatrol -> private gclass object
-        private GClass329 baseSteeringLogic = new GClass329();
+        private GClass327 baseSteeringLogic = new GClass327();
 
         protected double ActionElpasedTime => actionElapsedTime.ElapsedMilliseconds / 1000.0;
         protected double ActionElapsedTimeRemaining => Math.Max(0, ObjectiveManager.MinElapsedActionTime - ActionElpasedTime);

--- a/bepinex_dev/SPTQuestingBots/BotLogic/BotMonitor.cs
+++ b/bepinex_dev/SPTQuestingBots/BotLogic/BotMonitor.cs
@@ -265,7 +265,7 @@ namespace SPTQuestingBots.BotLogic
             }
 
             // If the raid is about to end, make the bot extract
-            float remainingRaidTime = Aki.SinglePlayer.Utils.InRaid.RaidTimeUtil.GetRemainingRaidSeconds();
+            float remainingRaidTime = SPT.SinglePlayer.Utils.InRaid.RaidTimeUtil.GetRemainingRaidSeconds();
             if (remainingRaidTime < ConfigController.Config.Questing.ExtractionRequirements.MustExtractTimeRemaining)
             {
                 LoggingController.LogInfo(botOwner.GetText() + " is ready to extract because the raid will be over in " + remainingRaidTime + " seconds.");
@@ -273,14 +273,14 @@ namespace SPTQuestingBots.BotLogic
             }
 
             // Ensure enough time has elapsed in the raid to prevent players from getting run-throughs
-            int minSurviveTime = Aki.SinglePlayer.Utils.InRaid.RaidChangesUtil.NewSurvivalTimeSeconds;
-            if (Aki.SinglePlayer.Utils.InRaid.RaidTimeUtil.GetElapsedRaidSeconds() < minSurviveTime)
+            int minSurviveTime = SPT.SinglePlayer.Utils.InRaid.RaidChangesUtil.NewSurvivalTimeSeconds;
+            if (SPT.SinglePlayer.Utils.InRaid.RaidTimeUtil.GetElapsedRaidSeconds() < minSurviveTime)
             {
                 return false;
             }
 
             System.Random random = new System.Random();
-            float initialRaidTimeFraction = Aki.SinglePlayer.Utils.InRaid.RaidChangesUtil.RaidTimeRemainingFraction;
+            float initialRaidTimeFraction = SPT.SinglePlayer.Utils.InRaid.RaidChangesUtil.RaidTimeRemainingFraction;
 
             // Select a random number of total quests the bot must complete before it's allowed to extract
             if (minTotalQuestsForExtract == int.MaxValue)

--- a/bepinex_dev/SPTQuestingBots/BotLogic/Follow/RegroupAction.cs
+++ b/bepinex_dev/SPTQuestingBots/BotLogic/Follow/RegroupAction.cs
@@ -16,7 +16,7 @@ namespace SPTQuestingBots.BotLogic.Follow
 
         public RegroupAction(BotOwner _BotOwner) : base(_BotOwner, 100)
         {
-            SetBaseAction(GClass460.CreateNode(BotLogicDecision.simplePatrol, BotOwner));
+            SetBaseAction(GClass459.CreateNode(BotLogicDecision.simplePatrol, BotOwner));
         }
 
         public override void Start()

--- a/bepinex_dev/SPTQuestingBots/BotLogic/LogicLayerMonitor.cs
+++ b/bepinex_dev/SPTQuestingBots/BotLogic/LogicLayerMonitor.cs
@@ -126,11 +126,11 @@ namespace SPTQuestingBots.BotLogic
             }
 
             // Find the field that stores the list of brain layers assigned to the bot
-            Type aICoreStrategyClassType = typeof(AICoreStrategyClass<BotLogicDecision>);
-            FieldInfo layerListField = aICoreStrategyClassType.GetField("list_0", BindingFlags.NonPublic | BindingFlags.Instance);
+            Type AICoreStrategyAbstractClassType = typeof(AICoreStrategyAbstractClass<BotLogicDecision>);
+            FieldInfo layerListField = AICoreStrategyAbstractClassType.GetField("list_0", BindingFlags.NonPublic | BindingFlags.Instance);
             if (layerListField == null)
             {
-                LoggingController.LogError("Could not find brain layer list in type " + aICoreStrategyClassType.FullName);
+                LoggingController.LogError("Could not find brain layer list in type " + AICoreStrategyAbstractClassType.FullName);
                 return emptyCollection;
             }
 

--- a/bepinex_dev/SPTQuestingBots/BotLogic/Objective/AmbushAction.cs
+++ b/bepinex_dev/SPTQuestingBots/BotLogic/Objective/AmbushAction.cs
@@ -13,7 +13,7 @@ namespace SPTQuestingBots.BotLogic.Objective
 
         public AmbushAction(BotOwner _BotOwner) : base(_BotOwner, 100)
         {
-            SetBaseAction(GClass460.CreateNode(BotLogicDecision.holdPosition, BotOwner));
+            SetBaseAction(GClass459.CreateNode(BotLogicDecision.holdPosition, BotOwner));
         }
 
         public override void Start()

--- a/bepinex_dev/SPTQuestingBots/BotLogic/Objective/HoldAtObjectiveAction.cs
+++ b/bepinex_dev/SPTQuestingBots/BotLogic/Objective/HoldAtObjectiveAction.cs
@@ -15,7 +15,7 @@ namespace SPTQuestingBots.BotLogic.Objective
 
         public HoldAtObjectiveAction(BotOwner _BotOwner) : base(_BotOwner, 100)
         {
-            SetBaseAction(GClass460.CreateNode(BotLogicDecision.search, BotOwner));
+            SetBaseAction(GClass459.CreateNode(BotLogicDecision.search, BotOwner));
         }
 
         public override void Start()

--- a/bepinex_dev/SPTQuestingBots/BotLogic/Objective/PlantItemAction.cs
+++ b/bepinex_dev/SPTQuestingBots/BotLogic/Objective/PlantItemAction.cs
@@ -11,7 +11,7 @@ namespace SPTQuestingBots.BotLogic.Objective
     {
         public PlantItemAction(BotOwner _BotOwner) : base(_BotOwner, 100)
         {
-            SetBaseAction(GClass460.CreateNode(BotLogicDecision.lay, BotOwner));
+            SetBaseAction(GClass459.CreateNode(BotLogicDecision.lay, BotOwner));
         }
 
         public override void Start()

--- a/bepinex_dev/SPTQuestingBots/BotLogic/Objective/UnlockDoorAction.cs
+++ b/bepinex_dev/SPTQuestingBots/BotLogic/Objective/UnlockDoorAction.cs
@@ -20,7 +20,7 @@ namespace SPTQuestingBots.BotLogic.Objective
         private Vector3? interactionPosition = null;
         private IResult keyGenerationResult = null;
         private KeyComponent keyComponent = null;
-        private DependencyGraph<IEasyBundle>.GClass3391 bundleLoader = null;
+        private DependencyGraph<IEasyBundle>.GClass3415 bundleLoader = null;
 
         public UnlockDoorAction(BotOwner _BotOwner) : base(_BotOwner, 100)
         {

--- a/bepinex_dev/SPTQuestingBots/Components/BotQuestBuilder.cs
+++ b/bepinex_dev/SPTQuestingBots/Components/BotQuestBuilder.cs
@@ -50,7 +50,7 @@ namespace SPTQuestingBots.Components
                 throw new ArgumentNullException(nameof(airdropPosition));
             }
 
-            if (!Aki.SinglePlayer.Utils.InRaid.RaidTimeUtil.HasRaidStarted())
+            if (!SPT.SinglePlayer.Utils.InRaid.RaidTimeUtil.HasRaidStarted())
             {
                 LoggingController.LogError("Airdrop chaser quest cannot be added when the raid is not in-progress");
                 return;
@@ -59,7 +59,7 @@ namespace SPTQuestingBots.Components
             Models.Quest airdopChaserQuest = createGoToPositionQuest(airdropPosition, "Airdrop Chaser", ConfigController.Config.Questing.BotQuests.AirdropChaser);
             if (airdopChaserQuest != null)
             {
-                float raidET = Aki.SinglePlayer.Utils.InRaid.RaidTimeUtil.GetElapsedRaidSeconds();
+                float raidET = SPT.SinglePlayer.Utils.InRaid.RaidTimeUtil.GetElapsedRaidSeconds();
                 
                 airdopChaserQuest.MaxRaidET = raidET + ConfigController.Config.Questing.BotQuests.AirdropBotInterestTime;
                 BotJobAssignmentFactory.AddQuest(airdopChaserQuest);

--- a/bepinex_dev/SPTQuestingBots/Components/LocationData.cs
+++ b/bepinex_dev/SPTQuestingBots/Components/LocationData.cs
@@ -34,7 +34,7 @@ namespace SPTQuestingBots.Components
         private Dictionary<WorldInteractiveObject, NoPowerTip> noPowerTipsForDoors = new Dictionary<WorldInteractiveObject, NoPowerTip>();
         private float maxExfilPointDistance = 0;
 
-        public bool IsScavRun => Aki.SinglePlayer.Utils.InRaid.RaidChangesUtil.IsScavRaid;
+        public bool IsScavRun => SPT.SinglePlayer.Utils.InRaid.RaidChangesUtil.IsScavRaid;
 
         private void Awake()
         {
@@ -837,7 +837,7 @@ namespace SPTQuestingBots.Components
                 return;
             }
 
-            if (!Aki.SinglePlayer.Utils.InRaid.RaidTimeUtil.HasRaidStarted())
+            if (!SPT.SinglePlayer.Utils.InRaid.RaidTimeUtil.HasRaidStarted())
             {
                 return;
             }

--- a/bepinex_dev/SPTQuestingBots/Components/Spawning/BotGenerator.cs
+++ b/bepinex_dev/SPTQuestingBots/Components/Spawning/BotGenerator.cs
@@ -289,7 +289,7 @@ namespace SPTQuestingBots.Components.Spawning
             }
 
             // Ensure the raid is progressing before running anything
-            float timeSinceSpawning = Aki.SinglePlayer.Utils.InRaid.RaidTimeUtil.GetSecondsSinceSpawning();
+            float timeSinceSpawning = SPT.SinglePlayer.Utils.InRaid.RaidTimeUtil.GetSecondsSinceSpawning();
             if (timeSinceSpawning < 0.01)
             {
                 return false;
@@ -495,7 +495,7 @@ namespace SPTQuestingBots.Components.Spawning
                     }
 
                     // Check if the bot group is allowed to spawn at this time in the raid
-                    float raidET = Aki.SinglePlayer.Utils.InRaid.RaidTimeUtil.GetElapsedRaidSeconds();
+                    float raidET = SPT.SinglePlayer.Utils.InRaid.RaidTimeUtil.GetElapsedRaidSeconds();
                     if ((raidET < botGroups[i].RaidETRangeToSpawn.Min) || (raidET > botGroups[i].RaidETRangeToSpawn.Max))
                     {
                         continue;

--- a/bepinex_dev/SPTQuestingBots/Components/Spawning/BotGenerator.cs
+++ b/bepinex_dev/SPTQuestingBots/Components/Spawning/BotGenerator.cs
@@ -446,7 +446,7 @@ namespace SPTQuestingBots.Components.Spawning
                     await Task.Delay(20);
 
                     GClass592 botProfileData = new GClass592(spawnSide, spawnType, botdifficulty, 0f, null);
-                    GClass591 botSpawnData = await GClass591.Create(botProfileData, ibotCreator, bots, botSpawnerClass);
+                    BotCreationDataClass botSpawnData = await BotCreationDataClass.Create(botProfileData, ibotCreator, bots, botSpawnerClass);
 
                     botSpawnInfo = new Models.BotSpawnInfo(botSpawnData, this);
                 }

--- a/bepinex_dev/SPTQuestingBots/Components/Spawning/PMCGenerator.cs
+++ b/bepinex_dev/SPTQuestingBots/Components/Spawning/PMCGenerator.cs
@@ -89,7 +89,7 @@ namespace SPTQuestingBots.Components.Spawning
 
                 // Set the maximum spawn time for the PMC group
                 float minTimeRemaining = ConfigController.Config.BotSpawns.PMCs.MinRaidTimeRemaining;
-                group.RaidETRangeToSpawn.Max = Aki.SinglePlayer.Utils.InRaid.RaidChangesUtil.OriginalEscapeTimeSeconds - minTimeRemaining;
+                group.RaidETRangeToSpawn.Max = SPT.SinglePlayer.Utils.InRaid.RaidChangesUtil.OriginalEscapeTimeSeconds - minTimeRemaining;
 
                 return group;
             };
@@ -191,12 +191,12 @@ namespace SPTQuestingBots.Components.Spawning
 
         private float getRaidTimeRemainingFraction()
         {
-            if (Aki.SinglePlayer.Utils.InRaid.RaidTimeUtil.HasRaidStarted())
+            if (SPT.SinglePlayer.Utils.InRaid.RaidTimeUtil.HasRaidStarted())
             {
-                return Aki.SinglePlayer.Utils.InRaid.RaidTimeUtil.GetRaidTimeRemainingFraction();
+                return SPT.SinglePlayer.Utils.InRaid.RaidTimeUtil.GetRaidTimeRemainingFraction();
             }
 
-            return (float)Aki.SinglePlayer.Utils.InRaid.RaidChangesUtil.RaidTimeRemainingFraction;
+            return (float)SPT.SinglePlayer.Utils.InRaid.RaidChangesUtil.RaidTimeRemainingFraction;
         }
     }
 }

--- a/bepinex_dev/SPTQuestingBots/Components/Spawning/PScavGenerator.cs
+++ b/bepinex_dev/SPTQuestingBots/Components/Spawning/PScavGenerator.cs
@@ -115,7 +115,7 @@ namespace SPTQuestingBots.Components.Spawning
                 // Set the minimum and maximum spawn times for the PScav group
                 float minTimeRemaining = ConfigController.Config.BotSpawns.PScavs.MinRaidTimeRemaining;
                 group.RaidETRangeToSpawn.Min = botSpawnSchedule[GeneratedBotCount];
-                group.RaidETRangeToSpawn.Max = Aki.SinglePlayer.Utils.InRaid.RaidChangesUtil.OriginalEscapeTimeSeconds - minTimeRemaining;
+                group.RaidETRangeToSpawn.Max = SPT.SinglePlayer.Utils.InRaid.RaidChangesUtil.OriginalEscapeTimeSeconds - minTimeRemaining;
 
                 return group;
             };
@@ -177,7 +177,7 @@ namespace SPTQuestingBots.Components.Spawning
                 throw new InvalidOperationException(locationID + " not found in Scav-raid settings data from server.");
             }
 
-            float originalEscapeTime = Aki.SinglePlayer.Utils.InRaid.RaidChangesUtil.OriginalEscapeTimeSeconds;
+            float originalEscapeTime = SPT.SinglePlayer.Utils.InRaid.RaidChangesUtil.OriginalEscapeTimeSeconds;
             int totalPScavs = (int)(locationData.CurrentLocation.MaxPlayers * ConfigController.Config.BotSpawns.PScavs.FractionOfMaxPlayers);
 
             // Parse the SPT raid-time-reduction settings
@@ -253,12 +253,12 @@ namespace SPTQuestingBots.Components.Spawning
 
         private float getRaidTimeRemainingFraction()
         {
-            if (Aki.SinglePlayer.Utils.InRaid.RaidTimeUtil.HasRaidStarted())
+            if (SPT.SinglePlayer.Utils.InRaid.RaidTimeUtil.HasRaidStarted())
             {
-                return Aki.SinglePlayer.Utils.InRaid.RaidTimeUtil.GetRaidTimeRemainingFraction();
+                return SPT.SinglePlayer.Utils.InRaid.RaidTimeUtil.GetRaidTimeRemainingFraction();
             }
 
-            return (float)Aki.SinglePlayer.Utils.InRaid.RaidChangesUtil.RaidTimeRemainingFraction;
+            return (float)SPT.SinglePlayer.Utils.InRaid.RaidChangesUtil.RaidTimeRemainingFraction;
         }
     }
 }

--- a/bepinex_dev/SPTQuestingBots/Controllers/ConfigController.cs
+++ b/bepinex_dev/SPTQuestingBots/Controllers/ConfigController.cs
@@ -7,7 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Aki.Common.Http;
+using SPT.Common.Http;
 using Newtonsoft.Json;
 using SPTQuestingBots.Configuration;
 using SPTQuestingBots.Models;
@@ -49,17 +49,17 @@ namespace SPTQuestingBots.Controllers
 
         public static void ReportInfoToServer(string message)
         {
-            Aki.Common.Utils.ServerLog.Info("Questing Bots", message);
+            SPT.Common.Utils.ServerLog.Info("Questing Bots", message);
         }
 
         public static void ReportWarningToServer(string message)
         {
-            Aki.Common.Utils.ServerLog.Warn("Questing Bots", message);
+            SPT.Common.Utils.ServerLog.Warn("Questing Bots", message);
         }
 
         public static void ReportErrorToServer(string message)
         {
-            Aki.Common.Utils.ServerLog.Error("Questing Bots", message);
+            SPT.Common.Utils.ServerLog.Error("Questing Bots", message);
         }
 
         public static string GetLoggingPath()

--- a/bepinex_dev/SPTQuestingBots/Controllers/ConfigController.cs
+++ b/bepinex_dev/SPTQuestingBots/Controllers/ConfigController.cs
@@ -215,7 +215,7 @@ namespace SPTQuestingBots.Controllers
                     }
                 }
 
-                obj = JsonConvert.DeserializeObject<T>(json, GClass1448.SerializerSettings);
+                obj = JsonConvert.DeserializeObject<T>(json, GClass1459.SerializerSettings);
 
                 return true;
             }

--- a/bepinex_dev/SPTQuestingBots/Helpers/BotBrainHelpers.cs
+++ b/bepinex_dev/SPTQuestingBots/Helpers/BotBrainHelpers.cs
@@ -212,8 +212,8 @@ namespace SPTQuestingBots.Helpers
 
         public static readonly WildSpawnType[] pmcSpawnTypes = new WildSpawnType[2]
         {
-            (WildSpawnType)Aki.PrePatch.AkiBotsPrePatcher.sptUsecValue,
-            (WildSpawnType)Aki.PrePatch.AkiBotsPrePatcher.sptBearValue
+            (WildSpawnType)SPT.PrePatch.AkiBotsPrePatcher.sptUsecValue,
+            (WildSpawnType)SPT.PrePatch.AkiBotsPrePatcher.sptBearValue
         };
 
         public static bool WillBotBeAPMC(BotOwner botOwner)
@@ -237,8 +237,8 @@ namespace SPTQuestingBots.Helpers
 
         public static EPlayerSide GetSideForWildSpawnType(WildSpawnType spawnType)
         {
-            WildSpawnType sptUsec = (WildSpawnType)Aki.PrePatch.AkiBotsPrePatcher.sptUsecValue;
-            WildSpawnType sptBear = (WildSpawnType)Aki.PrePatch.AkiBotsPrePatcher.sptBearValue;
+            WildSpawnType sptUsec = (WildSpawnType)SPT.PrePatch.AkiBotsPrePatcher.sptUsecValue;
+            WildSpawnType sptBear = (WildSpawnType)SPT.PrePatch.AkiBotsPrePatcher.sptBearValue;
 
             if (spawnType == sptUsec)
             {

--- a/bepinex_dev/SPTQuestingBots/Helpers/BotBrainHelpers.cs
+++ b/bepinex_dev/SPTQuestingBots/Helpers/BotBrainHelpers.cs
@@ -212,8 +212,8 @@ namespace SPTQuestingBots.Helpers
 
         public static readonly WildSpawnType[] pmcSpawnTypes = new WildSpawnType[2]
         {
-            (WildSpawnType)SPT.PrePatch.AkiBotsPrePatcher.sptUsecValue,
-            (WildSpawnType)SPT.PrePatch.AkiBotsPrePatcher.sptBearValue
+            WildSpawnType.pmcUSEC,
+            WildSpawnType.pmcBEAR
         };
 
         public static bool WillBotBeAPMC(BotOwner botOwner)
@@ -237,14 +237,11 @@ namespace SPTQuestingBots.Helpers
 
         public static EPlayerSide GetSideForWildSpawnType(WildSpawnType spawnType)
         {
-            WildSpawnType sptUsec = (WildSpawnType)SPT.PrePatch.AkiBotsPrePatcher.sptUsecValue;
-            WildSpawnType sptBear = (WildSpawnType)SPT.PrePatch.AkiBotsPrePatcher.sptBearValue;
-
-            if (spawnType == sptUsec)
+            if (spawnType == WildSpawnType.pmcUSEC)
             {
                 return EPlayerSide.Usec;
             }
-            else if (spawnType == sptBear)
+            else if (spawnType == WildSpawnType.pmcBEAR)
             {
                 return EPlayerSide.Bear;
             }

--- a/bepinex_dev/SPTQuestingBots/Helpers/BotPathingHelpers.cs
+++ b/bepinex_dev/SPTQuestingBots/Helpers/BotPathingHelpers.cs
@@ -77,7 +77,7 @@ namespace SPTQuestingBots.Helpers
                 return false;
             }
 
-            GClass423 pathFinder = (GClass423)pathFinderField.GetValue(botMover);
+            GClass422 pathFinder = (GClass422)pathFinderField.GetValue(botMover);
             if (pathFinder == null)
             {
                 return false;

--- a/bepinex_dev/SPTQuestingBots/Helpers/InteractiveObjectHelpers.cs
+++ b/bepinex_dev/SPTQuestingBots/Helpers/InteractiveObjectHelpers.cs
@@ -46,7 +46,7 @@ namespace SPTQuestingBots.Helpers
                     throw new ArgumentNullException(nameof(key));
                 }
 
-                GClass2964 unlockDoorInteractionResult = new GClass2964(key, null, true);
+                KeyInteractionResultClass unlockDoorInteractionResult = new KeyInteractionResultClass(key, null, true);
                 if (unlockDoorInteractionResult == null)
                 {
                     throw new InvalidOperationException(botOwner.GetText() + " cannot use key " + key.Item.LocalizedName() + " to unlock door " + door.Id);

--- a/bepinex_dev/SPTQuestingBots/Helpers/ItemHelpers.cs
+++ b/bepinex_dev/SPTQuestingBots/Helpers/ItemHelpers.cs
@@ -52,7 +52,7 @@ namespace SPTQuestingBots.Helpers
                 multiplier *= ConfigController.Config.Questing.BotQuestingRequirements.HearingSensor.LoudnessMultiplierHeadset;
             }
 
-            GClass2536 helmetTemplate = helmet?.Template as GClass2536;
+            GClass2550 helmetTemplate = helmet?.Template as GClass2550;
             switch (helmetTemplate?.DeafStrength)
             {
                 case EDeafStrength.Low:
@@ -91,7 +91,7 @@ namespace SPTQuestingBots.Helpers
                 }
 
                 // Initialize the transation to transfer the key to the bot
-                GStruct414<GClass2782> moveResult = InteractionsHandlerClass.Add(item, locationForItem, inventoryControllerClass, true);
+                GStruct414<GClass2798> moveResult = InteractionsHandlerClass.Add(item, locationForItem, inventoryControllerClass, true);
                 if (!moveResult.Succeeded)
                 {
                     LoggingController.LogError("Cannot move key " + item.LocalizedName() + " to inventory of " + botOwner.GetText());
@@ -144,7 +144,7 @@ namespace SPTQuestingBots.Helpers
                     {
                         LoggingController.LogInfo(botOwner.GetText() + " will receive " + item.LocalizedName() + " in its " + slot.ToString() + "...");
 
-                        return new GClass2769(grid, locationInGrid);
+                        return new ItemAddressClass(grid, locationInGrid);
                     }
                 }
             }
@@ -173,7 +173,7 @@ namespace SPTQuestingBots.Helpers
             return false;
         }
 
-        public static DependencyGraph<IEasyBundle>.GClass3391 LoadBundle(this Item item)
+        public static DependencyGraph<IEasyBundle>.GClass3415 LoadBundle(this Item item)
         {
             try
             {

--- a/bepinex_dev/SPTQuestingBots/Helpers/VersionCheckHelper.cs
+++ b/bepinex_dev/SPTQuestingBots/Helpers/VersionCheckHelper.cs
@@ -16,7 +16,7 @@ namespace SPTQuestingBots.Helpers
 
             try
             {
-                string assemblyName = "SPT.Common";
+                string assemblyName = "spt-common";
                 Assembly assembly = Assembly.Load(assemblyName);
                 if (assembly == null)
                 {

--- a/bepinex_dev/SPTQuestingBots/Helpers/VersionCheckHelper.cs
+++ b/bepinex_dev/SPTQuestingBots/Helpers/VersionCheckHelper.cs
@@ -16,7 +16,7 @@ namespace SPTQuestingBots.Helpers
 
             try
             {
-                string assemblyName = "Aki.Common";
+                string assemblyName = "SPT.Common";
                 Assembly assembly = Assembly.Load(assemblyName);
                 if (assembly == null)
                 {

--- a/bepinex_dev/SPTQuestingBots/Models/BotSpawnInfo.cs
+++ b/bepinex_dev/SPTQuestingBots/Models/BotSpawnInfo.cs
@@ -11,7 +11,7 @@ namespace SPTQuestingBots.Models
 {
     public class BotSpawnInfo
     {
-        public GClass591 Data { get; private set; }
+        public BotCreationDataClass Data { get; private set; }
         public BotGenerator BotGenerator { get; private set; }
         public Configuration.MinMaxConfig RaidETRangeToSpawn { get; private set; } = new Configuration.MinMaxConfig(0, double.MaxValue);
 
@@ -22,13 +22,13 @@ namespace SPTQuestingBots.Models
         public IReadOnlyCollection<BotOwner> SpawnedBots => bots.AsReadOnly();
         public int RemainingBotsToSpawn => Math.Max(0, Count - bots.Count);
 
-        public BotSpawnInfo(GClass591 data, BotGenerator botGenerator)
+        public BotSpawnInfo(BotCreationDataClass data, BotGenerator botGenerator)
         {
             Data = data;
             BotGenerator = botGenerator;
         }
 
-        public BotSpawnInfo(GClass591 data, BotGenerator botGenerator, Configuration.MinMaxConfig raidETRangeToSpawn) : this(data, botGenerator)
+        public BotSpawnInfo(BotCreationDataClass data, BotGenerator botGenerator, Configuration.MinMaxConfig raidETRangeToSpawn) : this(data, botGenerator)
         {
             RaidETRangeToSpawn = raidETRangeToSpawn;
         }
@@ -78,7 +78,7 @@ namespace SPTQuestingBots.Models
             }
 
             // Create a new spawn group for the bot
-            GClass591 newData = GClass591.CreateWithoutProfile(bot.SpawnProfileData);
+            BotCreationDataClass newData = BotCreationDataClass.CreateWithoutProfile(bot.SpawnProfileData);
             newData.AddProfile(bot.Profile);
             Models.BotSpawnInfo newGroup = new BotSpawnInfo(newData, BotGenerator);
             BotGenerator.AddNewBotGroup(newGroup);

--- a/bepinex_dev/SPTQuestingBots/Models/Quest.cs
+++ b/bepinex_dev/SPTQuestingBots/Models/Quest.cs
@@ -149,12 +149,12 @@ namespace SPTQuestingBots.Models
 
         public bool CanAssignBot(BotOwner bot)
         {
-            if (!Aki.SinglePlayer.Utils.InRaid.RaidTimeUtil.HasRaidStarted())
+            if (!SPT.SinglePlayer.Utils.InRaid.RaidTimeUtil.HasRaidStarted())
             {
                 return false;
             }
 
-            float raidTime = Aki.SinglePlayer.Utils.InRaid.RaidTimeUtil.GetElapsedRaidSeconds();
+            float raidTime = SPT.SinglePlayer.Utils.InRaid.RaidTimeUtil.GetElapsedRaidSeconds();
 
             if (RequiredSwitches.Any(s => !isSwitchInCorrectPosition(s.Key, s.Value)))
             {

--- a/bepinex_dev/SPTQuestingBots/Patches/ActivateBotsByWavePatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/ActivateBotsByWavePatch.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Aki.Reflection.Patching;
+using SPT.Reflection.Patching;
 using Comfort.Common;
 using EFT;
 using SPTQuestingBots.Controllers;

--- a/bepinex_dev/SPTQuestingBots/Patches/ActivateBotsByWavePatch2.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/ActivateBotsByWavePatch2.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Aki.Reflection.Patching;
+using SPT.Reflection.Patching;
 using EFT;
 using SPTQuestingBots.Controllers;
 

--- a/bepinex_dev/SPTQuestingBots/Patches/AddActivePlayerPatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/AddActivePlayerPatch.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Aki.Reflection.Patching;
+using SPT.Reflection.Patching;
 using Comfort.Common;
 using EFT;
 using SPTQuestingBots.Controllers;

--- a/bepinex_dev/SPTQuestingBots/Patches/AddEnemyPatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/AddEnemyPatch.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Aki.Reflection.Patching;
+using SPT.Reflection.Patching;
 using Comfort.Common;
 using EFT;
 using SPTQuestingBots.Controllers;
@@ -30,7 +30,7 @@ namespace SPTQuestingBots.Patches
 
             // This only matters in Scav raids
             // TO DO: This might also matter in PMC raids if a mod adds groups that are friendly to the player
-            /*if (!Aki.SinglePlayer.Utils.InRaid.RaidChangesUtil.IsScavRaid)
+            /*if (!SPT.SinglePlayer.Utils.InRaid.RaidChangesUtil.IsScavRaid)
             {
                 return true;
             }*/

--- a/bepinex_dev/SPTQuestingBots/Patches/AirdropLandPatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/AirdropLandPatch.cs
@@ -4,8 +4,8 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Aki.Custom.Airdrops;
-using Aki.Reflection.Patching;
+using SPT.Custom.Airdrops;
+using SPT.Reflection.Patching;
 using Comfort.Common;
 using EFT;
 

--- a/bepinex_dev/SPTQuestingBots/Patches/BotDiedPatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/BotDiedPatch.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Aki.Reflection.Patching;
+using SPT.Reflection.Patching;
 using Comfort.Common;
 using EFT;
 using HarmonyLib;

--- a/bepinex_dev/SPTQuestingBots/Patches/BotOwnerBrainActivatePatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/BotOwnerBrainActivatePatch.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Aki.Reflection.Patching;
+using SPT.Reflection.Patching;
 using Comfort.Common;
 using EFT;
 using HarmonyLib;

--- a/bepinex_dev/SPTQuestingBots/Patches/BotStandbyBugFixPatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/BotStandbyBugFixPatch.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Aki.Reflection.Patching;
+using SPT.Reflection.Patching;
 using EFT;
 using HarmonyLib;
 using SPTQuestingBots.Components.Spawning;

--- a/bepinex_dev/SPTQuestingBots/Patches/BotsControllerStopPatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/BotsControllerStopPatch.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Aki.Reflection.Patching;
+using SPT.Reflection.Patching;
 using Comfort.Common;
 using EFT;
 using SPTQuestingBots.Controllers;

--- a/bepinex_dev/SPTQuestingBots/Patches/CheckLookEnemyPatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/CheckLookEnemyPatch.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Aki.Reflection.Patching;
+using SPT.Reflection.Patching;
 using SPTQuestingBots.Controllers;
 
 namespace SPTQuestingBots.Patches

--- a/bepinex_dev/SPTQuestingBots/Patches/ExceptAIPatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/ExceptAIPatch.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Aki.Reflection.Patching;
+using SPT.Reflection.Patching;
 using EFT;
 using SPTQuestingBots.Controllers;
 using SPTQuestingBots.Helpers;
@@ -37,7 +37,7 @@ namespace SPTQuestingBots.Patches
 
         public static Type FindTargetType(string methodName)
         {
-            List<Type> targetTypeOptions = Aki.Reflection.Utils.PatchConstants.EftTypes
+            List<Type> targetTypeOptions = SPT.Reflection.Utils.PatchConstants.EftTypes
                 .Where(t => t.GetMethods().Any(m => m.Name.Contains(methodName)))
                 .ToList();
 

--- a/bepinex_dev/SPTQuestingBots/Patches/GameStartPatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/GameStartPatch.cs
@@ -30,7 +30,7 @@ namespace SPTQuestingBots.Patches
         }
 
         [PatchPostfix]
-        private static void PatchPostfix(ref IEnumerator __result, object __instance, float startDelay)
+        private static void PatchPostfix(ref IEnumerator __result, object __instance)
         {
             if (!IsDelayingGameStart)
             {

--- a/bepinex_dev/SPTQuestingBots/Patches/GameStartPatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/GameStartPatch.cs
@@ -181,12 +181,12 @@ namespace SPTQuestingBots.Patches
                 timers.Add(timer);
             }
 
-            FieldInfo bossWavesField = AccessTools.Field(SPT.Reflection.Utils.PatchConstants.LocalGameType, "gclass579_0");
-            GClass579 bossWaves = (GClass579)bossWavesField.GetValue(localGameObj);
+            FieldInfo bossWavesField = AccessTools.Field(SPT.Reflection.Utils.PatchConstants.LocalGameType, "gclass580_0");
+            BossSpawnWaveManagerClass bossWaves = (BossSpawnWaveManagerClass)bossWavesField.GetValue(localGameObj);
 
             //LoggingController.LogInfo("Found Boss Waves instance");
 
-            FieldInfo bossWavesTimersField = AccessTools.Field(typeof(GClass579), "list_0");
+            FieldInfo bossWavesTimersField = AccessTools.Field(typeof(BossSpawnWaveManagerClass), "list_0");
             ICollection bossWavesTimers = (ICollection)bossWavesTimersField.GetValue(bossWaves);
 
             LoggingController.LogInfo("Found Boss Waves timers (" + bossWavesTimers.Count + " timers)");
@@ -196,7 +196,7 @@ namespace SPTQuestingBots.Patches
                 timers.Add(timer);
             }
 
-            FieldInfo questTriggerField = AccessTools.Field(typeof(GClass579), "gclass580_0");
+            FieldInfo questTriggerField = AccessTools.Field(typeof(BossSpawnWaveManagerClass), "gclass580_0");
             GClass580 questTrigger = (GClass580)questTriggerField.GetValue(bossWaves);
 
             //LoggingController.LogInfo("Found Boss Waves Quest Trigger instance");

--- a/bepinex_dev/SPTQuestingBots/Patches/GameStartPatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/GameStartPatch.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Aki.Reflection.Patching;
+using SPT.Reflection.Patching;
 using Comfort.Common;
 using EFT;
 using HarmonyLib;
@@ -25,7 +25,7 @@ namespace SPTQuestingBots.Patches
 
         protected override MethodBase GetTargetMethod()
         {
-            Type localGameType = Aki.Reflection.Utils.PatchConstants.LocalGameType;
+            Type localGameType = SPT.Reflection.Utils.PatchConstants.LocalGameType;
             return localGameType.GetMethod("method_18", BindingFlags.Public | BindingFlags.Instance);
         }
 
@@ -166,7 +166,7 @@ namespace SPTQuestingBots.Patches
                 timers.Add(timer);
             }
 
-            FieldInfo wavesSpawnScenarioField = AccessTools.Field(Aki.Reflection.Utils.PatchConstants.LocalGameType, "wavesSpawnScenario_0");
+            FieldInfo wavesSpawnScenarioField = AccessTools.Field(SPT.Reflection.Utils.PatchConstants.LocalGameType, "wavesSpawnScenario_0");
             WavesSpawnScenario wavesSpawnScenario = (WavesSpawnScenario)wavesSpawnScenarioField.GetValue(localGameObj);
 
             //LoggingController.LogInfo("Found WavesSpawnScenario instance");
@@ -181,7 +181,7 @@ namespace SPTQuestingBots.Patches
                 timers.Add(timer);
             }
 
-            FieldInfo bossWavesField = AccessTools.Field(Aki.Reflection.Utils.PatchConstants.LocalGameType, "gclass579_0");
+            FieldInfo bossWavesField = AccessTools.Field(SPT.Reflection.Utils.PatchConstants.LocalGameType, "gclass579_0");
             GClass579 bossWaves = (GClass579)bossWavesField.GetValue(localGameObj);
 
             //LoggingController.LogInfo("Found Boss Waves instance");

--- a/bepinex_dev/SPTQuestingBots/Patches/GetListByZonePatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/GetListByZonePatch.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Aki.Reflection.Patching;
+using SPT.Reflection.Patching;
 using EFT;
 using SPTQuestingBots.Helpers;
 

--- a/bepinex_dev/SPTQuestingBots/Patches/InitBossSpawnLocationPatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/InitBossSpawnLocationPatch.cs
@@ -14,7 +14,7 @@ namespace SPTQuestingBots.Patches
     {
         protected override MethodBase GetTargetMethod()
         {
-            return typeof(GClass579).GetMethod("smethod_0", BindingFlags.Public | BindingFlags.Static);
+            return typeof(GClass580).GetMethod("smethod_0", BindingFlags.Public | BindingFlags.Static);
         }
 
         [PatchPostfix]

--- a/bepinex_dev/SPTQuestingBots/Patches/InitBossSpawnLocationPatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/InitBossSpawnLocationPatch.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Aki.Reflection.Patching;
+using SPT.Reflection.Patching;
 using EFT;
 using SPTQuestingBots.Controllers;
 

--- a/bepinex_dev/SPTQuestingBots/Patches/IsFollowerSuitableForBossPatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/IsFollowerSuitableForBossPatch.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Aki.Reflection.Patching;
+using SPT.Reflection.Patching;
 using Comfort.Common;
 using EFT;
 using SPTQuestingBots.Controllers;

--- a/bepinex_dev/SPTQuestingBots/Patches/MatchmakerFinalCountdownUpdatePatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/MatchmakerFinalCountdownUpdatePatch.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Aki.Reflection.Patching;
+using SPT.Reflection.Patching;
 using EFT.UI.Matchmaker;
 using TMPro;
 

--- a/bepinex_dev/SPTQuestingBots/Patches/OnBeenKilledByAggressorPatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/OnBeenKilledByAggressorPatch.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Aki.Reflection.Patching;
+using SPT.Reflection.Patching;
 using Comfort.Common;
 using EFT;
 using SPTQuestingBots.Controllers;

--- a/bepinex_dev/SPTQuestingBots/Patches/OnGameStartedPatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/OnGameStartedPatch.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Aki.Reflection.Patching;
+using SPT.Reflection.Patching;
 using EFT;
 
 namespace SPTQuestingBots.Patches

--- a/bepinex_dev/SPTQuestingBots/Patches/ServerRequestPatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/ServerRequestPatch.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Aki.Reflection.Patching;
+using SPT.Reflection.Patching;
 using SPTQuestingBots.Controllers;
 
 namespace SPTQuestingBots.Patches
@@ -59,7 +59,7 @@ namespace SPTQuestingBots.Patches
 
         public static Type FindTargetType(string methodName)
         {
-            List<Type> targetTypeOptions = Aki.Reflection.Utils.PatchConstants.EftTypes
+            List<Type> targetTypeOptions = SPT.Reflection.Utils.PatchConstants.EftTypes
                 .Where(t => t.GetMethods().Any(m => m.Name.Contains(methodName)))
                 .ToList();
 
@@ -73,12 +73,12 @@ namespace SPTQuestingBots.Patches
 
         private static float getRaidTimeRemainingFraction()
         {
-            if (Aki.SinglePlayer.Utils.InRaid.RaidTimeUtil.HasRaidStarted())
+            if (SPT.SinglePlayer.Utils.InRaid.RaidTimeUtil.HasRaidStarted())
             {
-                return Aki.SinglePlayer.Utils.InRaid.RaidTimeUtil.GetRaidTimeRemainingFraction();
+                return SPT.SinglePlayer.Utils.InRaid.RaidTimeUtil.GetRaidTimeRemainingFraction();
             }
 
-            return (float)Aki.SinglePlayer.Utils.InRaid.RaidChangesUtil.RaidTimeRemainingFraction;
+            return (float)SPT.SinglePlayer.Utils.InRaid.RaidChangesUtil.RaidTimeRemainingFraction;
         }
     }
 }

--- a/bepinex_dev/SPTQuestingBots/Patches/TarkovInitPatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/TarkovInitPatch.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Aki.Reflection.Patching;
+using SPT.Reflection.Patching;
 using BepInEx.Bootstrap;
 using EFT;
 using EFT.InputSystem;

--- a/bepinex_dev/SPTQuestingBots/Patches/TryToSpawnInZoneAndDelayPatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/TryToSpawnInZoneAndDelayPatch.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Aki.Reflection.Patching;
+using SPT.Reflection.Patching;
 using EFT;
 using EFT.Game.Spawning;
 using SPTQuestingBots.Controllers;

--- a/bepinex_dev/SPTQuestingBots/Patches/TryToSpawnInZoneAndDelayPatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/TryToSpawnInZoneAndDelayPatch.cs
@@ -19,7 +19,7 @@ namespace SPTQuestingBots.Patches
         }
 
         [PatchPostfix]
-        private static void PatchPostfix(BotZone botZone, GClass591 data, bool withCheckMinMax, bool newWave, List<ISpawnPoint> pointsToSpawn, bool forcedSpawn)
+        private static void PatchPostfix(BotZone botZone, BotCreationDataClass data, bool withCheckMinMax, bool newWave, List<ISpawnPoint> pointsToSpawn, bool forcedSpawn)
         {
             if (!QuestingBotsPluginConfig.ShowSpawnDebugMessages.Value)
             {

--- a/bepinex_dev/SPTQuestingBots/QuestingBotsPlugin.cs
+++ b/bepinex_dev/SPTQuestingBots/QuestingBotsPlugin.cs
@@ -25,8 +25,8 @@ namespace SPTQuestingBots
 
         private void Awake()
         {
-            Patches.TarkovInitPatch.MinVersion = "3.8.0.0";
-            Patches.TarkovInitPatch.MaxVersion = "3.8.99.0";
+            Patches.TarkovInitPatch.MinVersion = "3.9.0.0";
+            Patches.TarkovInitPatch.MaxVersion = "3.9.0.0";
 
             Logger.LogInfo("Loading QuestingBots...");
             LoggingController.Logger = Logger;

--- a/bepinex_dev/SPTQuestingBots/SPTQuestingBots.csproj
+++ b/bepinex_dev/SPTQuestingBots/SPTQuestingBots.csproj
@@ -34,20 +34,20 @@
     <Reference Include="0Harmony">
       <HintPath>..\..\..\..\BepInEx\core\0Harmony.dll</HintPath>
     </Reference>
-    <Reference Include="aki-custom">
-      <HintPath>..\..\..\..\BepInEx\plugins\spt\aki-custom.dll</HintPath>
+    <Reference Include="spt-custom">
+      <HintPath>..\..\..\..\BepInEx\plugins\spt\spt-custom.dll</HintPath>
     </Reference>
-    <Reference Include="aki-singleplayer">
-      <HintPath>..\..\..\..\BepInEx\plugins\spt\aki-singleplayer.dll</HintPath>
+    <Reference Include="spt-singleplayer">
+      <HintPath>..\..\..\..\BepInEx\plugins\spt\spt-singleplayer.dll</HintPath>
     </Reference>
-    <Reference Include="Aki.Common">
-      <HintPath>..\..\..\..\EscapeFromTarkov_Data\Managed\Aki.Common.dll</HintPath>
+    <Reference Include="spt-common">
+      <HintPath>..\..\..\..\BepInEx\plugins\spt\spt-common.dll</HintPath>
     </Reference>
-    <Reference Include="Aki.Reflection">
-      <HintPath>..\..\..\..\EscapeFromTarkov_Data\Managed\Aki.Reflection.dll</HintPath>
+    <Reference Include="spt-reflection">
+      <HintPath>..\..\..\..\BepInEx\plugins\spt\spt-reflection.dll</HintPath>
     </Reference>
-    <Reference Include="aki_PrePatch">
-      <HintPath>..\..\..\..\BepInEx\patchers\aki_PrePatch.dll</HintPath>
+    <Reference Include="spt-prepatch">
+      <HintPath>..\..\..\..\BepInEx\patchers\spt-prepatch.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
       <HintPath>..\..\..\..\EscapeFromTarkov_Data\Managed\Assembly-CSharp.dll</HintPath>

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
     "name": "SPTQuestingBots",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "main": "src/mod.js",
     "license": "MIT",
     "author": "DanW",
-    "akiVersion": ">=3.8.0 <3.9.0",
+    "akiVersion": "3.9.0",
     "scripts": {
         "setup": "npm i",
         "build": "node ./packageBuild.ts"

--- a/src/CommonUtils.ts
+++ b/src/CommonUtils.ts
@@ -1,8 +1,8 @@
 import modConfig from "../config/config.json";
 
-import type { ILogger } from "@spt-aki/models/spt/utils/ILogger";
-import type { IDatabaseTables } from "@spt-aki/models/spt/server/IDatabaseTables";
-import type { LocaleService } from "@spt-aki/services/LocaleService";
+import type { ILogger } from "@spt/models/spt/utils/ILogger";
+import type { IDatabaseTables } from "@spt/models/spt/server/IDatabaseTables";
+import type { LocaleService } from "@spt/services/LocaleService";
 
 export class CommonUtils
 {

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -4,37 +4,37 @@ import eftZoneAndItemPositions from "../config/zoneAndItemQuestPositions.json";
 import { CommonUtils } from "./CommonUtils";
 
 import type { DependencyContainer } from "tsyringe";
-import type { IPreAkiLoadMod } from "@spt-aki/models/external/IPreAkiLoadMod";
-import type { IPostDBLoadMod } from "@spt-aki/models/external/IPostDBLoadMod";
-import type { IPostAkiLoadMod } from "@spt-aki/models/external/IPostAkiLoadMod";
-import type { StaticRouterModService } from "@spt-aki/services/mod/staticRouter/StaticRouterModService";
-import type { DynamicRouterModService } from "@spt-aki/services/mod/dynamicRouter/DynamicRouterModService";
-import type { PreAkiModLoader } from "@spt-aki/loaders/PreAkiModLoader";
+import type { IPreSptLoadMod } from "@spt/models/external/IPreSptLoadMod";
+import type { IPostDBLoadMod } from "@spt/models/external/IPostDBLoadMod";
+import type { IPostSptLoadMod } from "@spt/models/external/IPostSptLoadMod";
+import type { StaticRouterModService } from "@spt/services/mod/staticRouter/StaticRouterModService";
+import type { DynamicRouterModService } from "@spt/services/mod/dynamicRouter/DynamicRouterModService";
+import type { PreSptModLoader } from "@spt/loaders/PreSptModLoader";
 
-import type { MinMax } from "@spt-aki/models/common/MinMax";
-import type { ConfigServer } from "@spt-aki/servers/ConfigServer";
-import type { ILogger } from "@spt-aki/models/spt/utils/ILogger";
-import type { DatabaseServer } from "@spt-aki/servers/DatabaseServer";
-import type { IDatabaseTables } from "@spt-aki/models/spt/server/IDatabaseTables";
-import type { LocaleService } from "@spt-aki/services/LocaleService";
-import type { QuestHelper } from "@spt-aki/helpers/QuestHelper";
-import type { ProfileHelper } from "@spt-aki/helpers/ProfileHelper";
-import type { VFS } from "@spt-aki/utils/VFS";
-import type { HttpResponseUtil } from "@spt-aki/utils/HttpResponseUtil";
-import type { RandomUtil } from "@spt-aki/utils/RandomUtil";
-import type { BotController } from "@spt-aki/controllers/BotController";
-import type { IGenerateBotsRequestData } from "@spt-aki/models/eft/bot/IGenerateBotsRequestData";
-import type { IBotBase } from "@spt-aki/models/eft/common/tables/IBotBase";
+import type { MinMax } from "@spt/models/common/MinMax";
+import type { ConfigServer } from "@spt/servers/ConfigServer";
+import type { ILogger } from "@spt/models/spt/utils/ILogger";
+import type { DatabaseServer } from "@spt/servers/DatabaseServer";
+import type { IDatabaseTables } from "@spt/models/spt/server/IDatabaseTables";
+import type { LocaleService } from "@spt/services/LocaleService";
+import type { QuestHelper } from "@spt/helpers/QuestHelper";
+import type { ProfileHelper } from "@spt/helpers/ProfileHelper";
+import type { VFS } from "@spt/utils/VFS";
+import type { HttpResponseUtil } from "@spt/utils/HttpResponseUtil";
+import type { RandomUtil } from "@spt/utils/RandomUtil";
+import type { BotController } from "@spt/controllers/BotController";
+import type { IGenerateBotsRequestData } from "@spt/models/eft/bot/IGenerateBotsRequestData";
+import type { IBotBase } from "@spt/models/eft/common/tables/IBotBase";
 
-import { ConfigTypes } from "@spt-aki/models/enums/ConfigTypes";
-import type { IBotConfig } from "@spt-aki/models/spt/config/IBotConfig";
-import type { IPmcConfig } from "@spt-aki/models/spt/config/IPmcConfig";
-import type { ILocationConfig } from "@spt-aki/models/spt/config/ILocationConfig";
-import type { IAirdropConfig } from "@spt-aki/models/spt/config/IAirdropConfig";
+import { ConfigTypes } from "@spt/models/enums/ConfigTypes";
+import type { IBotConfig } from "@spt/models/spt/config/IBotConfig";
+import type { IPmcConfig } from "@spt/models/spt/config/IPmcConfig";
+import type { ILocationConfig } from "@spt/models/spt/config/ILocationConfig";
+import type { IAirdropConfig } from "@spt/models/spt/config/IAirdropConfig";
 
 const modName = "SPTQuestingBots";
 
-class QuestingBots implements IPreAkiLoadMod, IPostAkiLoadMod, IPostDBLoadMod
+class QuestingBots implements IPreSptLoadMod, IPostSptLoadMod, IPostDBLoadMod
 {
     private commonUtils: CommonUtils
 
@@ -57,7 +57,7 @@ class QuestingBots implements IPreAkiLoadMod, IPostAkiLoadMod, IPostDBLoadMod
     private convertIntoPmcChanceOrig: Record<string, MinMax> = {};
     private basePScavConversionChance: number;
 	
-    public preAkiLoad(container: DependencyContainer): void 
+    public preSptLoad(container: DependencyContainer): void 
     {
         this.logger = container.resolve<ILogger>("WinstonLogger");
         const staticRouterModService = container.resolve<StaticRouterModService>("StaticRouterModService");
@@ -81,7 +81,7 @@ class QuestingBots implements IPreAkiLoadMod, IPostAkiLoadMod, IPostDBLoadMod
 
         // Game start
         // Needed to update Scav timer
-        staticRouterModService.registerStaticRouter(`StaticAkiGameStart${modName}`,
+        staticRouterModService.registerStaticRouter(`StaticSptGameStart${modName}`,
             [{
                 url: "/client/game/start",
                 // biome-ignore lint/suspicious/noExplicitAny: <explanation>
@@ -94,10 +94,10 @@ class QuestingBots implements IPreAkiLoadMod, IPostAkiLoadMod, IPostDBLoadMod
 
                     return output;
                 }
-            }], "aki"
+            }], "spt"
         );
 
-        // Apply a scalar factor to the SPT-AKI PMC conversion chances
+        // Apply a scalar factor to the SPT PMC conversion chances
         dynamicRouterModService.registerDynamicRouter(`DynamicAdjustPMCConversionChances${modName}`,
             [{
                 url: "/QuestingBots/AdjustPMCConversionChances/",
@@ -113,7 +113,7 @@ class QuestingBots implements IPreAkiLoadMod, IPostAkiLoadMod, IPostDBLoadMod
             }], "AdjustPMCConversionChances"
         );
 
-        // Apply a scalar factor to the SPT-AKI PScav conversion chance
+        // Apply a scalar factor to the SPT PScav conversion chance
         dynamicRouterModService.registerDynamicRouter(`DynamicAdjustPScavChance${modName}`,
             [{
                 url: "/QuestingBots/AdjustPScavChance/",
@@ -168,12 +168,12 @@ class QuestingBots implements IPreAkiLoadMod, IPostAkiLoadMod, IPostDBLoadMod
         dynamicRouterModService.registerDynamicRouter(`DynamicGenerateBot${modName}`,
             [{
                 url: "/QuestingBots/GenerateBot",
-                action: (url: string, info: IGenerateBotsRequestData, sessionID: string) => 
+                action: async (url: string, info: IGenerateBotsRequestData, sessionID: string) => 
                 {
                     const urlParts = url.split("/");
                     const pScavChance: number = Number(urlParts[urlParts.length - 1]);
 
-                    const bots = this.generateBots(info, sessionID, this.randomUtil.getChance100(pScavChance));
+                    const bots = await this.generateBots(info, sessionID, this.randomUtil.getChance100(pScavChance));
 
                     return this.httpResponseUtil.getBody(bots);
                 }
@@ -264,7 +264,7 @@ class QuestingBots implements IPreAkiLoadMod, IPostAkiLoadMod, IPostDBLoadMod
         }
     }
 	
-    public postAkiLoad(container: DependencyContainer): void
+    public postSptLoad(container: DependencyContainer): void
     {
         if (!modConfig.enabled)
         {
@@ -275,24 +275,24 @@ class QuestingBots implements IPreAkiLoadMod, IPostAkiLoadMod, IPostDBLoadMod
         this.removeBlacklistedBrainTypes();
 
         // If we find SWAG, MOAR or BetterSpawnsPlus, disable initial spawns
-        const preAkiModLoader = container.resolve<PreAkiModLoader>("PreAkiModLoader");
-        if (modConfig.bot_spawns.enabled && preAkiModLoader.getImportedModsNames().includes("SWAG"))
+        const preSptModLoader = container.resolve<PreSptModLoader>("PreSptModLoader");
+        if (modConfig.bot_spawns.enabled && preSptModLoader.getImportedModsNames().includes("SWAG"))
         {
             this.commonUtils.logWarning("SWAG Detected. Disabling bot spawning.");
             modConfig.bot_spawns.enabled = false;
         }
-        if (modConfig.bot_spawns.enabled && preAkiModLoader.getImportedModsNames().includes("DewardianDev-MOAR"))
+        if (modConfig.bot_spawns.enabled && preSptModLoader.getImportedModsNames().includes("DewardianDev-MOAR"))
         {
             this.commonUtils.logWarning("MOAR Detected. Disabling bot spawning.");
             modConfig.bot_spawns.enabled = false;
         }
-        if (modConfig.bot_spawns.enabled && preAkiModLoader.getImportedModsNames().includes("PreyToLive-BetterSpawnsPlus")) 
+        if (modConfig.bot_spawns.enabled && preSptModLoader.getImportedModsNames().includes("PreyToLive-BetterSpawnsPlus")) 
         {
             this.commonUtils.logWarning("BetterSpawnsPlus Detected. Disabling bot spawning.");
             modConfig.bot_spawns.enabled = false;
         }
 
-        if (preAkiModLoader.getImportedModsNames().includes("Andrudis-QuestManiac"))
+        if (preSptModLoader.getImportedModsNames().includes("Andrudis-QuestManiac"))
         {
             this.commonUtils.logWarning("QuestManiac Detected. This mod is known to cause performance issues when used with QuestingBots. No support will be provided.");
         }
@@ -524,9 +524,9 @@ class QuestingBots implements IPreAkiLoadMod, IPostAkiLoadMod, IPostDBLoadMod
         }
     }
 
-    private generateBots(info: IGenerateBotsRequestData, sessionID: string, shouldBePScavGroup: boolean) : IBotBase[]
+    private async generateBots(info: IGenerateBotsRequestData, sessionID: string, shouldBePScavGroup: boolean) : Promise<IBotBase[]>
     {
-        const bots = this.botController.generate(sessionID, info);
+        const bots = await this.botController.generate(sessionID, info);
 
         if (!shouldBePScavGroup)
         {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
         "outDir": "tmp",
         "baseUrl": ".",
         "paths": {
-            "@spt-aki/*": ["./types/*"]
+            "@spt/*": ["./types/*"]
         }
     },
     "lib": [


### PR DESCRIPTION
- Replace all occurrences of `Aki.` with `SPT.` in the imports of C# files
- Update library references to use spt files
- Change outdated classes to new names (i.e. `GClass460 -> GClass459`)
- Remove deprecated uses of `(WildSpawnType)Aki.PrePatch.AkiBotsPrePatcher.sptUsecValue` in favor of `WildSpawnType.pmcUSEC` & for bear.
- Updated imports in server mod to use `@spt/` instead of `@spt-aki` and updated import names
- Updated server mod functions to properly implement SPT interfaces
- Updated plugin min/max SPT version

Note:
- Did not include the 3.9.0 release of `DrakiaXYZ-BigBrain.dll`
- Did not include the update SPT 3.9.0 TS type declaration folder
- Did not remove unnecessary c# imports as previously done in #28 to keep diff clean
- Did not build and include the updated `dist/` files. These remain unchanged.
- Tested on SPT 3.9.0 with EFT 30626

I hope that this PR is easier to review.