### PR TITLE
Patch for PScav Names

### DIFF
--- a/bepinex_dev/SPTQuestingBots/Components/Spawning/PScavGenerator.cs
+++ b/bepinex_dev/SPTQuestingBots/Components/Spawning/PScavGenerator.cs
@@ -95,10 +95,18 @@ namespace SPTQuestingBots.Components.Spawning
             ServerRequestPatch.ForcePScavCount += botsInGroup;
             Models.BotSpawnInfo group = await GenerateBotGroup(WildSpawnType.assault, botDifficulty, botsInGroup);
 
+            // Set back to 0, since done asking from the server
+            ServerRequestPatch.ForcePScavCount = 0;
+
             // Set the minimum and maximum spawn times for the PScav group
             float minTimeRemaining = ConfigController.Config.BotSpawns.PScavs.MinRaidTimeRemaining;
             group.RaidETRangeToSpawn.Min = botSpawnSchedule[GeneratedBotCount];
             group.RaidETRangeToSpawn.Max = RaidHelpers.OriginalEscapeTimeSeconds - minTimeRemaining;
+
+            if (group.GeneratedBotCount != botsInGroup)
+            {
+                LoggingController.LogWarning($"PScavGenerator::GenerateBotGroupTask: Generated bots ({group.GeneratedBotCount}) not matching with requested ({botsInGroup}).");
+            }
 
             return group;
         }

--- a/bepinex_dev/SPTQuestingBots/Patches/PScavProfilePatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/PScavProfilePatch.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using EFT;
+using SPT.Reflection.Patching;
+using SPTQuestingBots.Controllers;
+
+namespace SPTQuestingBots.Patches
+{
+    internal class PScavProfilePatch : ModulePatch
+    {
+        protected override MethodBase GetTargetMethod()
+        {
+            // BotsPresets : GClass658
+            return typeof(GClass658).GetMethod("GetNewProfile", new Type[] { typeof(BotCreationDataClass), typeof(bool) });
+        }
+
+        [PatchPrefix]
+        protected static bool PatchPrefix(GClass658 __instance, ref Profile __result, BotCreationDataClass data, bool withDelete)
+        {
+            if (__instance.list_0.Count > 0)
+            {
+                if (ServerRequestPatch.ForcePScavCount > 0)
+                {
+                    // Filter list to only pscavs, if none - the client requests from the server
+                    // Use Info.Settings.Role instead of Side. Server always return x.Side == EPlayerSide.Savage
+                    List<Profile> filteredProfiles = __instance.list_0.ApplyFilter(x => x.Info.Settings.Role == WildSpawnType.assault && x.Nickname.Contains("("));
+                    __result = data.ChooseProfile(filteredProfiles, withDelete);
+
+                    return false;
+                }
+                else
+                {
+                    // Filter list to only scavs (No pmc nickname)
+                    List<Profile> filteredProfiles = __instance.list_0.ApplyFilter(x => (x.Info.Settings.Role == WildSpawnType.assault && !x.Nickname.Contains("(") || x.Info.Settings.Role != WildSpawnType.assault));
+                    __result = data.ChooseProfile(filteredProfiles, withDelete);
+
+                    return false;
+                }
+            }
+            __result = null;
+            return false;
+        }
+    }
+}

--- a/bepinex_dev/SPTQuestingBots/Patches/PScavProfilePatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/PScavProfilePatch.cs
@@ -1,13 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using EFT;
 using SPT.Reflection.Patching;
-using SPTQuestingBots.Controllers;
+using SPTQuestingBots.Helpers;
 
 namespace SPTQuestingBots.Patches
 {
@@ -28,7 +24,7 @@ namespace SPTQuestingBots.Patches
                 {
                     // Filter list to only pscavs, if none - the client requests from the server
                     // Use Info.Settings.Role instead of Side. Server always return x.Side == EPlayerSide.Savage
-                    List<Profile> filteredProfiles = __instance.list_0.ApplyFilter(x => x.Info.Settings.Role == WildSpawnType.assault && x.Nickname.Contains("("));
+                    List<Profile> filteredProfiles = __instance.list_0.ApplyFilter(x => x.Info.Settings.Role == WildSpawnType.assault && x.WillBeAPlayerScav());
                     __result = data.ChooseProfile(filteredProfiles, withDelete);
 
                     return false;
@@ -36,7 +32,7 @@ namespace SPTQuestingBots.Patches
                 else
                 {
                     // Filter list to only scavs (No pmc nickname)
-                    List<Profile> filteredProfiles = __instance.list_0.ApplyFilter(x => (x.Info.Settings.Role == WildSpawnType.assault && !x.Nickname.Contains("(") || x.Info.Settings.Role != WildSpawnType.assault));
+                    List<Profile> filteredProfiles = __instance.list_0.ApplyFilter(x => (x.Info.Settings.Role == WildSpawnType.assault && !x.WillBeAPlayerScav() || x.Info.Settings.Role != WildSpawnType.assault));
                     __result = data.ChooseProfile(filteredProfiles, withDelete);
 
                     return false;

--- a/bepinex_dev/SPTQuestingBots/Patches/ServerRequestPatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/ServerRequestPatch.cs
@@ -56,7 +56,7 @@ namespace SPTQuestingBots.Patches
             Class19<List<WaveInfoClass>> originalParams = (Class19<List<WaveInfoClass>>)legacyParams.Params;
             legacyParams.Params = new ModifiedParams(originalParams.conditions, pScavChance);
 
-            ForcePScavCount = Math.Max(0, ForcePScavCount - 1);
+            // ForcePScavCount = Math.Max(0, ForcePScavCount - 1);
         }
 
         internal class ModifiedParams

--- a/bepinex_dev/SPTQuestingBots/QuestingBotsPlugin.cs
+++ b/bepinex_dev/SPTQuestingBots/QuestingBotsPlugin.cs
@@ -61,7 +61,6 @@ namespace SPTQuestingBots
                 new Patches.OnBeenKilledByAggressorPatch().Enable();
                 new Patches.AirdropLandPatch().Enable();
                 new Patches.ServerRequestPatch().Enable();
-                new Patches.PScavProfilePatch().Enable();
                 new Patches.CheckLookEnemyPatch().Enable();
 
                 new Patches.Lighthouse.MineDirectionalShouldExplodePatch().Enable();
@@ -107,6 +106,8 @@ namespace SPTQuestingBots
                     }
                     if (ConfigController.Config.BotSpawns.PScavs.Enabled)
                     {
+                        new Patches.PScavProfilePatch().Enable();
+
                         BotGenerator.RegisterBotGenerator<Components.Spawning.PScavGenerator>(true);
                         Logger.LogInfo("Enabled PScav bot generation");
                     }

--- a/bepinex_dev/SPTQuestingBots/QuestingBotsPlugin.cs
+++ b/bepinex_dev/SPTQuestingBots/QuestingBotsPlugin.cs
@@ -61,6 +61,7 @@ namespace SPTQuestingBots
                 new Patches.OnBeenKilledByAggressorPatch().Enable();
                 new Patches.AirdropLandPatch().Enable();
                 new Patches.ServerRequestPatch().Enable();
+                new Patches.PScavProfilePatch().Enable();
                 new Patches.CheckLookEnemyPatch().Enable();
 
                 new Patches.Lighthouse.MineDirectionalShouldExplodePatch().Enable();

--- a/bepinex_dev/SPTQuestingBots/SPTQuestingBots.csproj
+++ b/bepinex_dev/SPTQuestingBots/SPTQuestingBots.csproj
@@ -243,6 +243,7 @@
     <Compile Include="Models\Pathing\StaticPathData.cs" />
     <Compile Include="Models\Questing\StoredQuestLocation.cs" />
     <Compile Include="Patches\Debug\HandleFinishedTaskPatch.cs" />
+    <Compile Include="Patches\PScavProfilePatch.cs" />
     <Compile Include="Patches\Spawning\ScavLimits\BotsControllerStopPatch.cs" />
     <Compile Include="Patches\Spawning\ScavLimits\NonWavesSpawnScenarioCreatePatch.cs" />
     <Compile Include="Patches\Spawning\ActivateBossesByWavePatch.cs" />


### PR DESCRIPTION
This patch filters profiles to only return PScavs when requested by QB PScav generator, and also handles not returning pscavs otherwise - since normal scav waves might randomly choose a pscav from the cache.

Will be enabled when PScav spawns are enabled in the config.

This patch hopes to tackle issue: https://github.com/dwesterwick/SPTQuestingBots/issues/53


About never running the original method when using PatchPrefix, I'm aware it's not generally recommended so I did try to do return null instead in Postfix, but with widely inconsistent results.