### PR TITLE
Expand Removal of Blacklisted Brains to Player Scavs

### DIFF
--- a/src/PMCConversionUtil.ts
+++ b/src/PMCConversionUtil.ts
@@ -2,10 +2,11 @@ import modConfig from "../config/config.json";
 
 import type { CommonUtils } from "./CommonUtils";
 import type { IPmcConfig } from "@spt/models/spt/config/IPmcConfig";
+import type { IBotConfig } from "@spt/models/spt/config/IBotConfig";
 
 export class PMCConversionUtil
 {
-    constructor(private commonUtils: CommonUtils, private iPmcConfig: IPmcConfig)
+    constructor(private commonUtils: CommonUtils, private iPmcConfig: IPmcConfig, private iBotConfig: IBotConfig)
     {
         
     }
@@ -29,13 +30,30 @@ export class PMCConversionUtil
                         continue;
                     }
 
-                    //this.commonUtils.logInfo(`Removing ${badBrains[i]} from ${pmcType} in ${map}...`);
+                    // this.commonUtils.logInfo(`Removing ${badBrains[i]} from ${pmcType} in ${map}...`);
                     delete mapBrains[badBrains[i]];
                     removedBrains++;
                 }
             }
         }
 
-        this.commonUtils.logInfo(`Removing blacklisted brain types from being used for PMC's...done. Removed entries: ${removedBrains}`);
+        for (const map in this.iBotConfig.playerScavBrainType)
+        {
+            const mapBrains = this.iBotConfig.playerScavBrainType[map];
+            
+            for (const i in badBrains)
+            {
+                if (mapBrains[badBrains[i]] === undefined)
+                {
+                    continue;
+                }
+
+                // this.commonUtils.logInfo(`Removing ${badBrains[i]} from playerscavs in ${map}...`);
+                delete mapBrains[badBrains[i]];
+                removedBrains++;
+            }
+        }
+
+        this.commonUtils.logInfo(`Removing blacklisted brain types from being used for PMC's and Player Scav's...done. Removed entries: ${removedBrains}`);
     }
 }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -181,7 +181,7 @@ class QuestingBots implements IPreSptLoadMod, IPostSptLoadMod, IPostDBLoadMod
         this.databaseTables = this.databaseServer.getTables();
         this.commonUtils = new CommonUtils(this.logger, this.databaseTables, this.localeService);
         this.botUtil = new BotUtil(this.commonUtils, this.databaseTables, this.iLocationConfig, this.iBotConfig, this.iPmcConfig);
-        this.pmcConversionUtil = new PMCConversionUtil(this.commonUtils, this.iPmcConfig);
+        this.pmcConversionUtil = new PMCConversionUtil(this.commonUtils, this.iPmcConfig, this.iBotConfig);
 
         if (!modConfig.enabled)
         {


### PR DESCRIPTION
If intended, this PR should also blacklist brain types under `config.bot_spawns.blacklisted_pmc_bot_brains` from being used for Player Scavs. Incompatible brain types inhibits their ability to quest (as per README.)