### PR TITLE
[Enhancement] Utilize EFT's Extraction Layer

### DIFF
--- a/bepinex_dev/SPTQuestingBots/Patches/BotExtractPatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/BotExtractPatch.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using Comfort.Common;
 using UnityEngine;
 using SPT.Reflection.Patching;
 using SPTQuestingBots.Controllers;
@@ -15,17 +14,12 @@ namespace SPTQuestingBots.Patches
         }
 
         [PatchPrefix]
-        protected static bool PatchPrefix(BotOwner botOwner)
+        protected static void PatchPrefix(BotOwner botOwner)
         {
             LoggingController.LogDebug($"{botOwner.GetText()} extracted.");
 
-            var botgame = Singleton<IBotGame>.Instance;
-            botgame.BotsController.BotDied(botOwner);
-            botgame.BotsController.DestroyInfo(botOwner.GetPlayer);
-            Object.DestroyImmediate(botOwner.gameObject);
-            Object.Destroy(botOwner);
-
-            return false;
+            botOwner.GetPlayer.gameObject.TryGetComponent<BotLogic.Objective.BotObjectiveManager>(out var objectiveManager);
+            Object.Destroy(objectiveManager);
         }
     }
 }

--- a/bepinex_dev/SPTQuestingBots/Patches/BotExtractPatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/BotExtractPatch.cs
@@ -1,0 +1,31 @@
+﻿using System.Reflection;
+using Comfort.Common;
+using UnityEngine;
+using SPT.Reflection.Patching;
+using SPTQuestingBots.Controllers;
+using EFT;
+
+namespace SPTQuestingBots.Patches
+{
+    internal class BotExtractPatch : ModulePatch
+    {
+        protected override MethodBase GetTargetMethod()
+        {
+            return typeof(BaseLocalGame<EftGamePlayerOwner>).GetMethod(nameof(BaseLocalGame<EftGamePlayerOwner>.BotDespawn));
+        }
+
+        [PatchPrefix]
+        protected static bool PatchPrefix(BotOwner botOwner)
+        {
+            LoggingController.LogDebug($"{botOwner.GetText()} extracted.");
+
+            var botgame = Singleton<IBotGame>.Instance;
+            botgame.BotsController.BotDied(botOwner);
+            botgame.BotsController.DestroyInfo(botOwner.GetPlayer);
+            Object.DestroyImmediate(botOwner.gameObject);
+            Object.Destroy(botOwner);
+
+            return false;
+        }
+    }
+}

--- a/bepinex_dev/SPTQuestingBots/QuestingBotsPlugin.cs
+++ b/bepinex_dev/SPTQuestingBots/QuestingBotsPlugin.cs
@@ -62,6 +62,7 @@ namespace SPTQuestingBots
                 new Patches.AirdropLandPatch().Enable();
                 new Patches.ServerRequestPatch().Enable();
                 new Patches.CheckLookEnemyPatch().Enable();
+                new Patches.BotExtractPatch().Enable();
 
                 new Patches.Lighthouse.MineDirectionalShouldExplodePatch().Enable();
                 new Patches.Lighthouse.LighthouseTraderZoneAwakePatch().Enable();

--- a/bepinex_dev/SPTQuestingBots/SPTQuestingBots.csproj
+++ b/bepinex_dev/SPTQuestingBots/SPTQuestingBots.csproj
@@ -243,6 +243,7 @@
     <Compile Include="Models\Pathing\StaticPathData.cs" />
     <Compile Include="Models\Questing\StoredQuestLocation.cs" />
     <Compile Include="Patches\Debug\HandleFinishedTaskPatch.cs" />
+    <Compile Include="Patches\BotExtractPatch.cs" />
     <Compile Include="Patches\PScavProfilePatch.cs" />
     <Compile Include="Patches\Spawning\ScavLimits\BotsControllerStopPatch.cs" />
     <Compile Include="Patches\Spawning\ScavLimits\NonWavesSpawnScenarioCreatePatch.cs" />


### PR DESCRIPTION
Since it doesn't look like SAIN will be updated any time soon, we can utilize EFT's extraction layer.

Patch was needed since BotDespawn() returns botOwner.gameObject to the pool, which was getting reused for the next batch of spawns. Leading to bots unable to initialize properly and quest. 

~Hopefully there aren't any side effects.~

Specifics:
`BotObjectiveManager.IsInitialized` set to true when reused.

~Full disclaimer, I also looked at SAIN's extract code and compared it with EFT's BotDespawn(). Thanks SAIN!~