### PR TITLE
Check If All Bots Have Spawned

### DIFF
--- a/bepinex_dev/SPTQuestingBots/Components/Spawning/BotGenerator.cs
+++ b/bepinex_dev/SPTQuestingBots/Components/Spawning/BotGenerator.cs
@@ -561,6 +561,13 @@ namespace SPTQuestingBots.Components.Spawning
                 {
                     yield return spawnBotGroup(botGroup);
                 }
+
+                while (botGroupsToSpawn.Any(g => !g.HaveAllBotsSpawned))
+                {
+                    LoggingController.LogDebug($"Waiting for " + botGroupsToSpawn.Count + " " + BotTypeName + " group(s) to finish spawning...");
+                    yield return new WaitForSeconds(0.5f);
+                }
+                LoggingController.LogDebug($"Waiting for " + botGroupsToSpawn.Count + " " + BotTypeName + " group(s) to finish spawning...done.");
             }
             finally
             {


### PR DESCRIPTION
This PR adds a small check in `spawnBotGroups()` to ensure all `botGroupsToSpawn` have spawned  before proceeding to set `IsSpawningBots = false`

For issue: https://github.com/dwesterwick/SPTQuestingBots/issues/69