### PR TITLE
Further Bot Filtering for Debug

### DIFF
--- a/bepinex_dev/SPTQuestingBots/Components/DebugData.cs
+++ b/bepinex_dev/SPTQuestingBots/Components/DebugData.cs
@@ -15,6 +15,7 @@ namespace SPTQuestingBots.Components
 {
     public class DebugData : MonoBehaviour
     {
+        public static List<string> BotFilter = new List<string>();
         private readonly static float markerRadius = 0.5f;
 
         private List<AbstractDebugGizmo> gizmos = new List<AbstractDebugGizmo>();
@@ -33,7 +34,12 @@ namespace SPTQuestingBots.Components
         protected void Awake()
         {
             QuestingBotsPluginConfig.QuestOverlayFontSize.SettingChanged += (object sender, EventArgs e) => { updateGuiStyles(sender, e); };
+            QuestingBotsPluginConfig.BotFilter.SettingChanged += (object sender, EventArgs e) =>
+            {
+                ValidateBotFilter(QuestingBotsPluginConfig.BotFilter.Value);
+            };
 
+            ValidateBotFilter(QuestingBotsPluginConfig.BotFilter.Value);
             gizmos.Add(new PlayerCoordinatesGizmo());
         }
 
@@ -134,6 +140,26 @@ namespace SPTQuestingBots.Components
             questText += "\nDistance: ";
 
             gizmos.Add(new JobAssignmentGizmo(jobAssignment, position, questText, markerRadius, Color.blue));
+        }
+
+        private static void ValidateBotFilter(string configString)
+        {
+            BotFilter.Clear();
+            if (configString.IsNullOrEmpty())
+                return;
+
+            string[] bounds = configString.Split(',');
+            foreach (var bound in bounds)
+            {
+                if (int.TryParse(bound, out int _))
+                {
+                    string botName = "Bot" + bound.Trim();
+                    BotFilter.Add(botName);
+                    continue;
+                }
+                //LoggingController.LogError("DebugData::ValidateBotFilter Unable to parse bot filters.");
+                BotFilter.Clear();
+            }
         }
     }
 }

--- a/bepinex_dev/SPTQuestingBots/Components/DebugData.cs
+++ b/bepinex_dev/SPTQuestingBots/Components/DebugData.cs
@@ -39,7 +39,9 @@ namespace SPTQuestingBots.Components
                 ValidateBotFilter(QuestingBotsPluginConfig.BotFilter.Value);
             };
 
-            ValidateBotFilter(QuestingBotsPluginConfig.BotFilter.Value);
+            // Reset to default since filter from previous raid won't matter in the next
+            QuestingBotsPluginConfig.BotFilter.BoxedValue = "";
+
             gizmos.Add(new PlayerCoordinatesGizmo());
         }
 

--- a/bepinex_dev/SPTQuestingBots/Helpers/DebugHelpers.cs
+++ b/bepinex_dev/SPTQuestingBots/Helpers/DebugHelpers.cs
@@ -178,6 +178,10 @@ namespace SPTQuestingBots.Helpers
 
         public static bool CanDisplayDebugData(this BotOwner bot, BepInEx.Configuration.ConfigEntry<QuestingBotType> config)
         {
+            // Check if filter not empty (no filter), and bot is not included in the filter
+            if (!DebugData.BotFilter.IsNullOrEmpty() && !DebugData.BotFilter.Contains(bot.GetPlayer.name))
+                return false;
+
             if (bot.GetObjectiveManager()?.IsQuestingAllowed == true)
             {
                 // Check if overlays are enabled for questing bosses (leaders)

--- a/bepinex_dev/SPTQuestingBots/QuestingBotsPluginConfig.cs
+++ b/bepinex_dev/SPTQuestingBots/QuestingBotsPluginConfig.cs
@@ -102,6 +102,7 @@ namespace SPTQuestingBots
         public static ConfigEntry<bool> ShowQuestInfoForSpawnSearchQuests;
         public static ConfigEntry<int> QuestOverlayFontSize;
         public static ConfigEntry<int> QuestOverlayMaxDistance;
+        public static ConfigEntry<string> BotFilter;
 
         public static ConfigEntry<bool> CreateQuestLocations;
         public static ConfigEntry<bool> ShowCurrentLocation;
@@ -187,7 +188,9 @@ namespace SPTQuestingBots
             QuestOverlayMaxDistance = Config.Bind("Debug", "Max Distance (m) to Show Quest Info",
                 100, new ConfigDescription("Quest markers and info overlays will only be shown if the objective location is within this distance from you", new AcceptableValueRange<int>(10, 300)));
             QuestOverlayFontSize = Config.Bind("Debug", "Font Size for Quest Info",
-                16, new ConfigDescription("Font Size for Quest Overlays", new AcceptableValueRange<int>(12, 36)));
+                16, new ConfigDescription("Font Size for Quest Overlays", new AcceptableValueRange<int>(12, 36))); 
+            BotFilter = Config.Bind("Debug", "Bot Filter",
+                "", new ConfigDescription("Show debug info only for bots listed e.g 2,4", null, new ConfigurationManagerAttributes { IsAdvanced = true }));
 
             CreateQuestLocations = Config.Bind("Custom Quest Locations", "Enable Quest Location Saving",
                 false, new ConfigDescription("Allow custom quest locations to be saved", null, new ConfigurationManagerAttributes { Order = 4, IsAdvanced = true }));


### PR DESCRIPTION
This PR adds a Config to be able to set bot filters, aside from `QuestingBotType`, based on the bot name (e.g. `Bot2`) for debug use. Has been handy to only show the bot/bots being followed on screen.

Can also be expanded to filter logs logged for a certain bot.