### PR TITLE
Fika External Mod Handling

### DIFF
--- a/Client/BotLogic/ExternalMods/ExternalModHandler.cs
+++ b/Client/BotLogic/ExternalMods/ExternalModHandler.cs
@@ -23,6 +23,8 @@ namespace QuestingBots.BotLogic.ExternalMods
         public static DonutsModInfo DonutsModInfo { get; private set; } = new DonutsModInfo();
         public static PerformanceImprovementsModInfo PerformanceImprovementsModInfo { get; private set; } = new PerformanceImprovementsModInfo();
         public static PleaseJustFightModInfo PleaseJustFightModInfo { get; private set; } = new PleaseJustFightModInfo();
+        public static FikaModInfo FikaModInfo { get; private set; } = new FikaModInfo();
+        public static HeadlessModInfo HeadlessModInfo { get; private set; } = new HeadlessModInfo();
 
         private static List<AbstractExternalModInfo> externalMods = new List<AbstractExternalModInfo>
         {
@@ -30,7 +32,9 @@ namespace QuestingBots.BotLogic.ExternalMods
             LootingBotsModInfo,
             DonutsModInfo,
             PerformanceImprovementsModInfo,
-            PleaseJustFightModInfo
+            PleaseJustFightModInfo,
+            FikaModInfo,
+            HeadlessModInfo
         };
 
         public static AbstractExtractFunction CreateExtractFunction(this BotOwner _botOwner) => SAINModInfo.CreateExtractFunction(_botOwner);

--- a/Client/BotLogic/ExternalMods/ModInfo/FikaModInfo.cs
+++ b/Client/BotLogic/ExternalMods/ModInfo/FikaModInfo.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Comfort.Common;
+using QuestingBots.Utils;
+
+namespace QuestingBots.BotLogic.ExternalMods.ModInfo
+{
+    public class FikaModInfo : AbstractExternalModInfo
+    {
+        public override string GUID { get; } = "com.fika.core";
+
+        public override Version MinCompatibleVersion => new Version("2.1.1");
+        public override Version MaxCompatibleVersion => new Version("2.99.99");
+
+        public override string IncompatibilityMessage => $"Installed Fika ({PluginInfo.Metadata.Version}) is not compatible with Questing Bots spawning system. Please upgrade Fika to {MinCompatibleVersion} or newer to use the QB spawning system.";
+
+        public override bool IsCompatible()
+        {
+            if (!Singleton<ConfigUtil>.Instance.CurrentConfig.BotSpawns.Enabled)
+            {
+                return true;
+            }
+
+            if (base.IsCompatible())
+            {
+                return true;
+            }
+
+            NotificationManagerClass.DisplayWarningNotification(IncompatibilityMessage, EFT.Communications.ENotificationDurationType.Infinite);
+            Singleton<LoggingUtil>.Instance.LogErrorToServerConsole(IncompatibilityMessage);
+            // TODO: Disable BotSpawns config and disable spawn patches. Raid may not start.
+            // Singleton<ConfigUtil>.Instance.CurrentConfig.BotSpawns.Enabled = false;
+            // DisableSpawnPatches();
+            return false;
+        }
+
+        public override bool CheckInteropAvailability() => true;
+    }
+}

--- a/Client/BotLogic/ExternalMods/ModInfo/HeadlessModInfo.cs
+++ b/Client/BotLogic/ExternalMods/ModInfo/HeadlessModInfo.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Reflection;
+using Comfort.Common;
+using HarmonyLib;
+using QuestingBots.Utils;
+
+namespace QuestingBots.BotLogic.ExternalMods.ModInfo
+{
+    public class HeadlessModInfo : AbstractExternalModInfo
+    {
+        public override string GUID { get; } = "com.fika.headless";
+
+        public override Version MinCompatibleVersion => new Version("1.4.0");
+        public override Version MaxCompatibleVersion => new Version("1.4.99");
+
+        public override string IncompatibilityMessage => $"Installed Fika Headless ({PluginInfo.Metadata.Version}) is not compatible with Questing Bots spawning system. Please upgrade Fika Headless to {MinCompatibleVersion} or newer to use the QB spawning system.";
+
+        public MethodInfo RunMemoryCleanupMethod;
+
+        public override bool IsCompatible()
+        {
+            if (!Singleton<ConfigUtil>.Instance.CurrentConfig.BotSpawns.Enabled) return true;
+
+            if (base.IsCompatible())
+            {
+                Type headlessGameType = AccessTools.TypeByName("Fika.Headless.Classes.GameMode.HeadlessGame");
+                if (headlessGameType != null)
+                {
+                    RunMemoryCleanupMethod = AccessTools.Method(headlessGameType, "RunMemoryCleanup");
+                    if (RunMemoryCleanupMethod != null)
+                    {
+                        new Patches.Spawning.HeadlessGameStartPatch().Enable();
+
+                        return true;
+                    }
+                }
+            }
+
+            NotificationManagerClass.DisplayWarningNotification(IncompatibilityMessage, EFT.Communications.ENotificationDurationType.Long);
+            Singleton<LoggingUtil>.Instance.LogWarningToServerConsole(IncompatibilityMessage);
+            // TODO: Decide if to disable BotSpawns config and spawn patches. Spawns will work, however the game start will not be delayed.
+            // Singleton<ConfigUtil>.Instance.CurrentConfig.BotSpawns.Enabled = false;
+            // DisableSpawnPatches();
+            return false;
+        }
+
+        public override bool CheckInteropAvailability() => true;
+    }
+}

--- a/Client/Patches/Spawning/GameStartPatch.cs
+++ b/Client/Patches/Spawning/GameStartPatch.cs
@@ -22,7 +22,6 @@ namespace QuestingBots.Patches.Spawning
 
         private static readonly List<BossLocationSpawn> missedBossWaves = new List<BossLocationSpawn>();
         private static FieldInfo wavesSpawnScenarioField = null!;
-        private static object localGameObj = null!;
 
         protected override MethodBase GetTargetMethod()
         {
@@ -40,16 +39,14 @@ namespace QuestingBots.Patches.Spawning
                 return;
             }
 
-            localGameObj = __instance;
-
             IEnumerator originalEnumeratorWithMessage = addDebugMessageAfterEnumerator(__result, "Original start-game IEnumerator completed");
-            __result = new Models.EnumeratorCollection(originalEnumeratorWithMessage, waitForBotGenerators(), spawnMissedWaves());
+            __result = new Models.EnumeratorCollection(originalEnumeratorWithMessage, WaitForBotGenerators(), spawnMissedWavesCoroutine());
 
             Singleton<LoggingUtil>.Instance.LogDebug("Injected wait-for-bot-gen IEnumerator into start-game IEnumerator");
 
             if (QuestingBotsPluginConfig.ShowSpawnDebugMessages.Value)
             {
-                writeSpawnMessages();
+                WriteSpawnMessages(__instance);
             }
         }
 
@@ -69,7 +66,14 @@ namespace QuestingBots.Patches.Spawning
             Singleton<LoggingUtil>.Instance.LogDebug(message);
         }
 
-        private static IEnumerator spawnMissedWaves()
+        private static IEnumerator spawnMissedWavesCoroutine()
+        {
+            SpawnMissedWaves();
+
+            yield break;
+        }
+
+        public static void SpawnMissedWaves()
         {
             IsDelayingGameStart = false;
 
@@ -84,26 +88,25 @@ namespace QuestingBots.Patches.Spawning
             }
 
             Singleton<LoggingUtil>.Instance.LogInfo("Spawned all missed boss waves");
-
-            yield return null;
         }
 
-        private static IEnumerator waitForBotGenerators()
+        public static IEnumerator WaitForBotGenerators(Action? onComplete = null)
         {
+            const float waitIterationDuration = 100;
+            WaitForSeconds waitForSeconds = new WaitForSeconds(waitIterationDuration / 1000f);
             bool hadToWait = false;
-            float waitIterationDuration = 100;
 
             while (BotGenerator.RemainingBotGenerators > 0)
             {
                 if (!hadToWait)
                 {
-                    Singleton<LoggingUtil>.Instance.LogInfo("Waiting for " + BotGenerator.RemainingBotGenerators + " bot generators...");
+                    Singleton<LoggingUtil>.Instance.LogInfo($"Waiting for {BotGenerator.RemainingBotGenerators} bot generators...");
                 }
                 hadToWait = true;
 
-                yield return new WaitForSeconds(waitIterationDuration / 1000f);
+                yield return waitForSeconds;
 
-                TimeHasComeScreenClassChangeStatusPatch.ChangeStatus("Generating " + BotGenerator.CurrentBotGeneratorType + "s", BotGenerator.CurrentBotGeneratorProgress / 100f);
+                TimeHasComeScreenClassChangeStatusPatch.ChangeStatus($"Generating {BotGenerator.CurrentBotGeneratorType}s", BotGenerator.CurrentBotGeneratorProgress / 100f);
             }
 
             if (hadToWait)
@@ -112,18 +115,20 @@ namespace QuestingBots.Patches.Spawning
             }
 
             TimeHasComeScreenClassChangeStatusPatch.RestorePreviousStatus();
+
+            onComplete?.Invoke();
         }
 
-        private static void writeSpawnMessages()
+        public static void WriteSpawnMessages(object gameObj)
         {
-            if (localGameObj as LocalGame == null)
+            if (gameObj as LocalGame == null)
             {
                 Singleton<LoggingUtil>.Instance.LogError("Cannot write WavesSpawnScenario spawn messages for the current BaseLocalGame because it is not a LocalGame");
 
                 return;
             }
 
-            WavesSpawnScenario wavesSpawnScenario = (WavesSpawnScenario)wavesSpawnScenarioField.GetValue(localGameObj);
+            WavesSpawnScenario? wavesSpawnScenario = wavesSpawnScenarioField.GetValue(gameObj) as WavesSpawnScenario;
             if (wavesSpawnScenario?.SpawnWaves == null)
             {
                 Singleton<LoggingUtil>.Instance.LogInfo("WavesSpawnScenario has no BotWaveDataClass waves");
@@ -131,9 +136,9 @@ namespace QuestingBots.Patches.Spawning
                 return;
             }
 
-            foreach (BotWaveDataClass wave in wavesSpawnScenario.SpawnWaves.ToArray())
+            foreach (BotWaveDataClass wave in wavesSpawnScenario.SpawnWaves)
             {
-                Singleton<LoggingUtil>.Instance.LogInfo("BotWaveDataClass at " + wave.Time + "s: " + wave.BotsCount + " bots of type " + wave.WildSpawnType.ToString());
+                Singleton<LoggingUtil>.Instance.LogInfo($"BotWaveDataClass at {wave.Time}s: {wave.BotsCount} bots of type {wave.WildSpawnType}");
             }
         }
     }

--- a/Client/Patches/Spawning/HeadlessGameStartPatch.cs
+++ b/Client/Patches/Spawning/HeadlessGameStartPatch.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Comfort.Common;
+using QuestingBots.BotLogic.ExternalMods;
+using QuestingBots.Utils;
+using SPT.Reflection.Patching;
+using UnityEngine;
+
+namespace QuestingBots.Patches.Spawning
+{
+    /// <summary>
+    /// This patch ensures the game start is delayed for all Fika clients until all BotGenerators have finished.
+    /// </summary>
+    /// <remarks>
+    /// This patch injects <see cref="WaitForBotGenerators"/> to Fika's <c>HeadlessGame.RunMemoryCleanup</c> Task,
+    /// which runs before <c>HeadlessGameController.WaitForHeadlessInit</c>,
+    /// which sends the packet to all players that they may proceed with the countdown.
+    /// </remarks>
+    public class HeadlessGameStartPatch : ModulePatch
+    {
+        protected override MethodBase GetTargetMethod()
+        {
+            return ExternalModHandler.HeadlessModInfo.RunMemoryCleanupMethod;
+        }
+
+        [PatchPostfix]
+        protected static void PatchPostfix(ref Task __result, object __instance)
+        {
+            if (!GameStartPatch.IsDelayingGameStart)
+            {
+                Singleton<LoggingUtil>.Instance.LogInfo("The game start is not being delayed");
+                return;
+            }
+
+            __result = WaitForBotGenerators(__result, __instance);
+            Singleton<LoggingUtil>.Instance.LogDebug("Injected wait-for-bot-gen Task into Headless run-memory-cleanup Task");
+
+            if (QuestingBotsPluginConfig.ShowSpawnDebugMessages.Value)
+            {
+                GameStartPatch.WriteSpawnMessages(__instance);
+            }
+        }
+
+        private static async Task WaitForBotGenerators(Task originalTask, object gameObj)
+        {
+            if (!(gameObj is MonoBehaviour game))
+            {
+                Singleton<LoggingUtil>.Instance.LogWarning($"The game start is not being delayed. Unexpected Type for HeadlessGame: {gameObj.GetType().FullName}");
+                return;
+            }
+
+            await originalTask;
+            Singleton<LoggingUtil>.Instance.LogDebug("Original run-memory-cleanup Task completed");
+
+            TaskCompletionClass source = new TaskCompletionClass();
+            game.StartCoroutine(GameStartPatch.WaitForBotGenerators(source.Complete));
+            await source.Task;
+
+            GameStartPatch.SpawnMissedWaves();
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces compatibility with Fika, especially the headless client:
- Mod Infos to handle compatibility
- GameStartPatch changes:
    - Separate `SpawnMissedWaves` IEnumerator wrapper
    - `WaitForBotGenerators` to take in an optional param `Action onComplete`
    - `WriteSpawnMessages` to take in LocalGame instance instead of static field
- HeadlessGameStartPatch - This patch delays the game start for all Fika clients in a headless game until all bot generators have finished
