### PR TITLE
Couple Minor Fixes for 4.0

### DIFF
--- a/Client/BehaviorExtensions/CustomLogicDelayedUpdate.cs
+++ b/Client/BehaviorExtensions/CustomLogicDelayedUpdate.cs
@@ -103,7 +103,7 @@ namespace QuestingBots.BehaviorExtensions
             BotOwner.SetTargetMoveSpeed(1f);
             
             // Open doors blocking the bot's path
-            BotOwner.DoorOpener.ManualUpdate();
+            BotOwner.DoorOpener.UpdateDoorInteractionStatus();
         }
 
         public void UpdateBotSteering()

--- a/Client/BotLogic/ExternalMods/Functions/Extract/SAINExtractFunction.cs
+++ b/Client/BotLogic/ExternalMods/Functions/Extract/SAINExtractFunction.cs
@@ -22,8 +22,8 @@ namespace QuestingBots.BotLogic.ExternalMods.Functions.Extract
 
         public override bool IsTryingToExtract() => IsMonitoredLayerActive();
 
-        private bool tryExtractSingleBot(BotOwner botOwner) => SAIN.Plugin.SAINInterop.TryExtractBot(botOwner);
-        private bool trySetExfilForBot(BotOwner botOwner) => SAIN.Plugin.SAINInterop.TrySetExfilForBot(botOwner);
+        private bool tryExtractSingleBot(BotOwner botOwner) => SAIN.Interop.SAINInterop.TryExtractBot(botOwner);
+        private bool trySetExfilForBot(BotOwner botOwner) => SAIN.Interop.SAINInterop.TrySetExfilForBot(botOwner);
 
         public override bool TryInstructBotToExtract()
         {

--- a/Client/BotLogic/ExternalMods/Functions/Hearing/SAINHearingFunction.cs
+++ b/Client/BotLogic/ExternalMods/Functions/Hearing/SAINHearingFunction.cs
@@ -20,7 +20,7 @@ namespace QuestingBots.BotLogic.ExternalMods.Functions.Hearing
 
         public override bool TryIgnoreHearing(bool value, bool ignoreUnderFire, float duration = 0)
         {
-            if (!SAIN.Plugin.SAINInterop.IgnoreHearing(BotOwner, value, false, duration))
+            if (!SAIN.Interop.SAINInterop.IgnoreHearing(BotOwner, value, false, duration))
             {
                 Singleton<LoggingUtil>.Instance.LogWarning("Cannot instruct " + BotOwner.GetText() + " to ignore hearing. SAIN Interop not initialized properly or is outdated.");
 

--- a/Client/BotLogic/ExternalMods/Interop/SAINInterop.cs
+++ b/Client/BotLogic/ExternalMods/Interop/SAINInterop.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.AI;
 
-namespace SAIN.Plugin
+namespace SAIN.Interop
 {
     internal static class SAINInterop
     {
@@ -59,7 +59,7 @@ namespace SAIN.Plugin
             {
                 _SAINInteropInited = true;
 
-                _SAINExternalType = Type.GetType("SAIN.Plugin.External, SAIN");
+                _SAINExternalType = Type.GetType("SAIN.Interop.SAINExternal, SAIN");
 
                 // Only try to get the methods if we have the type
                 if (_SAINExternalType != null)

--- a/Client/BotLogic/ExternalMods/ModInfo/SAINModInfo.cs
+++ b/Client/BotLogic/ExternalMods/ModInfo/SAINModInfo.cs
@@ -25,7 +25,7 @@ namespace QuestingBots.BotLogic.ExternalMods.ModInfo
 
         public override bool CheckInteropAvailability()
         {
-            if (SAIN.Plugin.SAINInterop.Init())
+            if (SAIN.Interop.SAINInterop.Init())
             {
                 CanUseInterop = true;
             }

--- a/Client/Components/LocationData.cs
+++ b/Client/Components/LocationData.cs
@@ -431,6 +431,13 @@ namespace QuestingBots.Components
                 return null;
             }
 
+            // Fika Headless client does not have a MainPlayer
+            // TODO: Find an alternative?
+            if (Singleton<GameWorld>.Instance.MainPlayer == null)
+            {
+                return null;
+            }
+
             return Singleton<GameWorld>.Instance.MainPlayer.Position;
         }
 

--- a/Client/Patches/ReturnToPoolPatch.cs
+++ b/Client/Patches/ReturnToPoolPatch.cs
@@ -20,6 +20,10 @@ namespace QuestingBots.Patches
             {
                 UnityEngine.Object.Destroy(objectiveManager);
             }
+            if (gameObject.TryGetComponent<BotLogic.BotMonitor.BotMonitorController>(out var botMonitorController))
+            {
+                UnityEngine.Object.Destroy(botMonitorController);
+            }
         }
     }
 }


### PR DESCRIPTION
- Destroy `BotMonitorController` alongside BotObjectiveManager in ReturnToPoolPatch
  - Fixes next spawn after a bot extracts
- Use `UpdateDoorInteractionStatus` instead of ManualUpdate when opening doors
- `GameWorld.MainPlayer` null check, Fika Headless does not have a MainPlayer
  - TODO: Maybe find an alternative way to find spawnpoint for spawn rush quest
- Update to latest namespace for SAIN Interop
