### PR TITLE
SPT 4.1 Performance Improvements

### DIFF
--- a/Client/BotLogic/BotMonitor/BotMonitorController.cs
+++ b/Client/BotLogic/BotMonitor/BotMonitorController.cs
@@ -14,23 +14,35 @@ namespace QuestingBots.BotLogic.BotMonitor
     public class BotMonitorController : MonoBehaviourDelayedUpdate
     {
         private BotOwner botOwner = null!;
-        private BotObjectiveManager objectiveManager = null!;
+        private bool _initComplete = false;
         private Dictionary<Type, AbstractBotMonitor> monitors = new Dictionary<Type, AbstractBotMonitor>();
         private BotQuestingDecisionMonitor questingDecisionMonitor = null!;
 
         public BotQuestingDecision CurrentDecision => questingDecisionMonitor?.CurrentDecision ?? BotQuestingDecision.None;
         public bool HasAQuestingBoss => questingDecisionMonitor?.HasAQuestingBoss ?? false;
 
+        public static BotMonitorController GetBotMonitorController(BotOwner botOwner)
+        {
+            BotMonitorController botMonitorController = botOwner.gameObject.GetOrAddComponent<BotLogic.BotMonitor.BotMonitorController>();
+            botMonitorController.Init(botOwner);
+
+            return botMonitorController;
+        }
+
         public void Init(BotOwner _botOwner)
         {
             botOwner = _botOwner;
-            objectiveManager = botOwner.GetOrAddObjectiveManager();
 
             addSensors();
         }
 
         private void addSensors()
         {
+            if (_initComplete)
+            {
+                return;
+            }
+
             monitors.Add(typeof(BotHearingMonitor), new BotHearingMonitor(botOwner));
             monitors.Add(typeof(BotMountedGunMonitor), new BotMountedGunMonitor(botOwner));
             monitors.Add(typeof(BotExtractMonitor), new BotExtractMonitor(botOwner));
@@ -41,6 +53,8 @@ namespace QuestingBots.BotLogic.BotMonitor
 
             questingDecisionMonitor = new BotQuestingDecisionMonitor(botOwner);
             monitors.Add(typeof(BotQuestingDecisionMonitor), questingDecisionMonitor);
+
+            _initComplete = true;
         }
 
         protected void Start()
@@ -55,6 +69,7 @@ namespace QuestingBots.BotLogic.BotMonitor
                 return;
             }
 
+            BotObjectiveManager? objectiveManager = botOwner.GetObjectiveManager();
             if (objectiveManager == null)
             {
                 return;

--- a/Client/BotLogic/BotMonitor/Monitors/AbstractBotMonitor.cs
+++ b/Client/BotLogic/BotMonitor/Monitors/AbstractBotMonitor.cs
@@ -11,9 +11,10 @@ namespace QuestingBots.BotLogic.BotMonitor.Monitors
 {
     public abstract class AbstractBotMonitor
     {
-        protected BotOwner BotOwner { get; private set; } = null!;
-        protected BotObjectiveManager ObjectiveManager { get; private set; } = null!;
-        protected BotMonitorController BotMonitor { get; private set; } = null!;
+        protected BotOwner BotOwner { get; private set; }
+
+        protected BotObjectiveManager? ObjectiveManager => BotOwner.GetObjectiveManager();
+        protected BotMonitorController? BotMonitor => ObjectiveManager?.BotMonitor;
 
         public AbstractBotMonitor(BotOwner _botOwner)
         {
@@ -23,12 +24,6 @@ namespace QuestingBots.BotLogic.BotMonitor.Monitors
             }
 
             BotOwner = _botOwner;
-            ObjectiveManager = BotOwner.GetOrAddObjectiveManager();
-
-            if (ObjectiveManager != null)
-            {
-                BotMonitor = ObjectiveManager.BotMonitor;
-            }
         }
 
         public virtual void Start() { }

--- a/Client/BotLogic/BotMonitor/Monitors/BotCombatMonitor.cs
+++ b/Client/BotLogic/BotMonitor/Monitors/BotCombatMonitor.cs
@@ -76,6 +76,11 @@ namespace QuestingBots.BotLogic.BotMonitor.Monitors
 
         private bool updateCombatState(bool inCombat)
         {
+            if (BotMonitor == null)
+            {
+                return false;
+            }
+
             if (inCombat)
             {
                 BotMonitor.GetMonitor<BotHealthMonitor>().PauseHealthMonitoring();

--- a/Client/BotLogic/BotMonitor/Monitors/BotExtractMonitor.cs
+++ b/Client/BotLogic/BotMonitor/Monitors/BotExtractMonitor.cs
@@ -47,7 +47,7 @@ namespace QuestingBots.BotLogic.BotMonitor.Monitors
         {
             random = new System.Random();
 
-            if (BotGenerator.TryGetBotGroupFromAnyGenerator(BotOwner, out BotSpawnInfo botGroup))
+            if (Singleton<GameWorld>.Instance.GetComponent<BotGenerationManager>().TryGetBotGroupFromAnyGenerator(BotOwner, out BotSpawnInfo botGroup))
             {
                 maxQuestsScalingFactor = botGroup.IsInitialSpawn ? RaidHelpers.InitialRaidTimeFraction : 1;
             }

--- a/Client/BotLogic/BotMonitor/Monitors/BotHearingMonitor.cs
+++ b/Client/BotLogic/BotMonitor/Monitors/BotHearingMonitor.cs
@@ -87,17 +87,22 @@ namespace QuestingBots.BotLogic.BotMonitor.Monitors
 
         private bool isSuspicious()
         {
+            if (BotMonitor == null)
+            {
+                return false;
+            }
+
             bool wasSuspiciousTooLong = totalSuspiciousTimer.ElapsedMilliseconds / 1000 > maxSuspiciousTime;
             //if (wasSuspiciousTooLong && totalSuspiciousTimer.IsRunning)
             //{
             //    Singleton<LoggingUtil>.Instance.LogInfo(BotOwner.GetText() + " has been suspicious for too long");
             //}
 
-            if (!wasSuspiciousTooLong && BotMonitor.GetMonitor<BotHearingMonitor>().shouldBeSuspicious(suspiciousTime))
+            if (!wasSuspiciousTooLong && shouldBeSuspicious(suspiciousTime))
             {
                 if (!BotHiveMindMonitor.GetValueForBot(BotHiveMindSensorType.IsSuspicious, BotOwner))
                 {
-                    suspiciousTime = BotMonitor.GetMonitor<BotHearingMonitor>().updateSuspiciousTime();
+                    suspiciousTime = updateSuspiciousTime();
                     //Singleton<LoggingUtil>.Instance.LogInfo("Bot " + BotOwner.GetText() + " will be suspicious for " + suspiciousTime + " seconds");
 
                     BotMonitor.GetMonitor<BotLootingMonitor>().TryPreventBotFromLooting((float)suspiciousTime);

--- a/Client/BotLogic/BotMonitor/Monitors/BotQuestingDecisionMonitor.cs
+++ b/Client/BotLogic/BotMonitor/Monitors/BotQuestingDecisionMonitor.cs
@@ -101,7 +101,7 @@ namespace QuestingBots.BotLogic.BotMonitor
 
         private BotQuestingDecision getFollowerDecision()
         {
-            Controllers.BotJobAssignmentFactory.InactivateAllJobAssignmentsForBot(BotOwner.Profile.Id);
+            Controllers.BotJobAssignmentController.InactivateAllJobAssignmentsForBot(BotOwner.Profile.Id);
 
             if (BotMonitor.GetMonitor<BotCombatMonitor>().IsInCombat)
             {

--- a/Client/BotLogic/BotMonitor/Monitors/BotQuestingDecisionMonitor.cs
+++ b/Client/BotLogic/BotMonitor/Monitors/BotQuestingDecisionMonitor.cs
@@ -41,10 +41,10 @@ namespace QuestingBots.BotLogic.BotMonitor
 
         private Components.BotQuestBuilder botQuestBuilder = null!;
 
-        public bool MustQuestBeforeFollowing => ObjectiveManager.PrioritizeQuestingOverFollowing || ObjectiveManager.HasTeleportingAssignment;
+        public bool MustQuestBeforeFollowing => (ObjectiveManager != null) && (ObjectiveManager.PrioritizeQuestingOverFollowing || ObjectiveManager.HasTeleportingAssignment);
 
-        private bool allowedToTakeABreak() => ObjectiveManager.IsAllowedToTakeABreak();
-        private bool allowedToInvestigate() => ObjectiveManager.IsAllowedToInvestigate();
+        private bool allowedToTakeABreak() => (ObjectiveManager != null) && ObjectiveManager.IsAllowedToTakeABreak();
+        private bool allowedToInvestigate() => (ObjectiveManager != null) && ObjectiveManager.IsAllowedToInvestigate();
 
         public BotQuestingDecisionMonitor(BotOwner _botOwner) : base(_botOwner) { }
 
@@ -75,6 +75,11 @@ namespace QuestingBots.BotLogic.BotMonitor
 
         public override void UpdateIfQuesting()
         {
+            if (BotMonitor == null)
+            {
+                return;
+            }
+
             HasAQuestingBoss = BotMonitor.GetMonitor<BotQuestingMonitor>().HasAQuestingBoss;
             CurrentDecision = getDecision();
         }
@@ -101,6 +106,11 @@ namespace QuestingBots.BotLogic.BotMonitor
 
         private BotQuestingDecision getFollowerDecision()
         {
+            if (BotMonitor == null)
+            {
+                return BotQuestingDecision.None;
+            }
+
             Controllers.BotJobAssignmentController.InactivateAllJobAssignmentsForBot(BotOwner.Profile.Id);
 
             if (BotMonitor.GetMonitor<BotCombatMonitor>().IsInCombat)
@@ -167,6 +177,11 @@ namespace QuestingBots.BotLogic.BotMonitor
 
         private BotQuestingDecision getSoloDecision()
         {
+            if ((ObjectiveManager == null) || (BotMonitor == null))
+            {
+                return BotQuestingDecision.None;
+            }
+
             if (!ObjectiveManager.IsQuestingAllowed)
             {
                 return BotQuestingDecision.None;
@@ -265,7 +280,16 @@ namespace QuestingBots.BotLogic.BotMonitor
 
         private void setLootingHiveMindState(bool value) => BotHiveMindMonitor.UpdateValueForBot(BotHiveMindSensorType.WantsToLoot, BotOwner, value);
 
-        private bool isFollowerTooFarFromBossForQuesting() => BotMonitor.GetMonitor<BotQuestingMonitor>().DistanceToBoss > getFollowerTargetDistanceQuesting();
+        private bool isFollowerTooFarFromBossForQuesting()
+        {
+            if (BotMonitor == null)
+            {
+                return false;
+            }
+
+            return BotMonitor.GetMonitor<BotQuestingMonitor>().DistanceToBoss > getFollowerTargetDistanceQuesting();
+        }
+
         private double getFollowerTargetDistanceQuesting()
         {
             MinMaxConfig targetFollowerRangeQuesting = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuestingRequirements.MaxFollowerDistance.TargetRangeQuesting;
@@ -278,7 +302,16 @@ namespace QuestingBots.BotLogic.BotMonitor
             return targetFollowerRangeQuesting.Max;
         }
 
-        private bool isFollowerTooFarFromBossForCombat() => BotMonitor.GetMonitor<BotQuestingMonitor>().DistanceToBoss > getFollowerTargetDistanceCombat();
+        private bool isFollowerTooFarFromBossForCombat()
+        {
+            if (BotMonitor == null)
+            {
+                return false;
+            }
+
+            return BotMonitor.GetMonitor<BotQuestingMonitor>().DistanceToBoss > getFollowerTargetDistanceCombat();
+        }
+
         private double getFollowerTargetDistanceCombat()
         {
             MinMaxConfig targetFollowerRangeQuesting = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuestingRequirements.MaxFollowerDistance.TargetRangeCombat;

--- a/Client/BotLogic/BotMonitor/Monitors/BotQuestingMonitor.cs
+++ b/Client/BotLogic/BotMonitor/Monitors/BotQuestingMonitor.cs
@@ -33,12 +33,17 @@ namespace QuestingBots.BotLogic.BotMonitor.Monitors
 
         public float DistanceToBoss => BotHiveMindMonitor.GetDistanceToBoss(BotOwner);
         public bool NeedToRegroupWithFollowers => followersTooFarTimer.ElapsedMilliseconds > Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuestingRequirements.MaxFollowerDistance.MaxWaitTime * 1000;
-        public bool StuckTooManyTimes => ObjectiveManager.StuckCount >= Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.StuckBotDetection.MaxCount;
+        public bool StuckTooManyTimes => (ObjectiveManager != null) && (ObjectiveManager.StuckCount >= Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.StuckBotDetection.MaxCount);
 
         public BotQuestingMonitor(BotOwner _botOwner) : base(_botOwner) { }
 
         public override void UpdateIfQuesting()
         {
+            if ((ObjectiveManager == null) || (BotMonitor == null))
+            {
+                return;
+            }
+
             HasABoss = BotHiveMindMonitor.HasBoss(BotOwner);
             HasAQuestingBoss = HasABoss && BotHiveMindMonitor.GetValueForBossOfBot(BotHiveMindSensorType.CanQuest, BotOwner);
             DoesBossNeedHelp = HasABoss && doesBossNeedHelp();

--- a/Client/BotLogic/Follow/BotFollowerLayer.cs
+++ b/Client/BotLogic/Follow/BotFollowerLayer.cs
@@ -42,17 +42,17 @@ namespace QuestingBots.BotLogic.Follow
                 return previousState;
             }
 
+            BotQuestingDecisionMonitor decisionMonitor = objectiveManager.BotMonitor.GetMonitor<BotQuestingDecisionMonitor>();
+            if (decisionMonitor.CurrentDecision != BotQuestingDecision.FollowBoss)
+            {
+                return updatePreviousState(false);
+            }
+
             float pauseRequestTime = getPauseRequestTime();
             if (pauseRequestTime > 0)
             {
                 //Singleton<LoggingUtil>.Instance.LogInfo("Pausing layer for " + pauseRequestTime + "s...");
                 return pauseLayer(pauseRequestTime);
-            }
-
-            BotQuestingDecisionMonitor decisionMonitor = objectiveManager.BotMonitor.GetMonitor<BotQuestingDecisionMonitor>();
-            if (decisionMonitor.CurrentDecision != BotQuestingDecision.FollowBoss)
-            {
-                return updatePreviousState(false);
             }
 
             setNextAction(BotActionType.FollowBoss, "FollowBoss");

--- a/Client/BotLogic/Follow/BotFollowerRegroupLayer.cs
+++ b/Client/BotLogic/Follow/BotFollowerRegroupLayer.cs
@@ -38,17 +38,17 @@ namespace QuestingBots.BotLogic.Follow
                 return previousState;
             }
 
+            BotQuestingDecisionMonitor decisionMonitor = objectiveManager.BotMonitor.GetMonitor<BotQuestingDecisionMonitor>();
+            if (decisionMonitor.CurrentDecision != BotQuestingDecision.HelpBoss)
+            {
+                return updatePreviousState(false);
+            }
+
             float pauseRequestTime = getPauseRequestTime();
             if (pauseRequestTime > 0)
             {
                 //Singleton<LoggingUtil>.Instance.LogInfo("Pausing layer for " + pauseRequestTime + "s...");
                 return pauseLayer(pauseRequestTime);
-            }
-
-            BotQuestingDecisionMonitor decisionMonitor = objectiveManager.BotMonitor.GetMonitor<BotQuestingDecisionMonitor>();
-            if (decisionMonitor.CurrentDecision != BotQuestingDecision.HelpBoss)
-            {
-                return updatePreviousState(false);
             }
 
             setNextAction(BotActionType.FollowerRegroup, "RegroupWithBoss");

--- a/Client/BotLogic/HiveMind/BotHiveMindMonitor.cs
+++ b/Client/BotLogic/HiveMind/BotHiveMindMonitor.cs
@@ -418,7 +418,7 @@ namespace QuestingBots.BotLogic.HiveMind
                 Singleton<LoggingUtil>.Instance.LogInfo("Bot " + bot.GetText() + " is now a follower for " + boss.GetText());
                 botFollowers[boss].Add(bot);
 
-                BotJobAssignmentFactory.CheckBotJobAssignmentValidity(boss);
+                BotJobAssignmentController.CheckBotJobAssignmentValidity(boss);
             }
         }
 

--- a/Client/BotLogic/HiveMind/BotHiveMindMonitor.cs
+++ b/Client/BotLogic/HiveMind/BotHiveMindMonitor.cs
@@ -280,7 +280,7 @@ namespace QuestingBots.BotLogic.HiveMind
             }
 
             // If the bot was spawned by this mod, create a new spawn group for it
-            if (BotGenerator.TryGetBotGroupFromAnyGenerator(bot, out Models.BotSpawnInfo matchingGroupData))
+            if (Singleton<GameWorld>.Instance.GetComponent<BotGenerationManager>().TryGetBotGroupFromAnyGenerator(bot, out Models.BotSpawnInfo matchingGroupData))
             {
                 matchingGroupData.SeparateBotOwner(bot);
             }

--- a/Client/BotLogic/HiveMind/BotHiveMindMonitor.cs
+++ b/Client/BotLogic/HiveMind/BotHiveMindMonitor.cs
@@ -117,7 +117,6 @@ namespace QuestingBots.BotLogic.HiveMind
             return sensor!.GetLastLootingTimeForBoss(bot);
         }
 
-        [Benchmark]
         public static void RegisterBot(BotOwner bot)
         {
             if (bot == null)
@@ -168,7 +167,7 @@ namespace QuestingBots.BotLogic.HiveMind
 
         public static ReadOnlyCollection<BotOwner> GetFollowers(BotOwner bot)
         {
-            return botFollowers.ContainsKey(bot) ? new ReadOnlyCollection<BotOwner>(botFollowers[bot]) : new ReadOnlyCollection<BotOwner>(new BotOwner[0]);
+            return botFollowers.ContainsKey(bot) ? botFollowers[bot].AsReadOnly() : new ReadOnlyCollection<BotOwner>(new BotOwner[0]);
         }
 
         public static ReadOnlyCollection<BotOwner> GetAllGroupMembers(BotOwner bot)

--- a/Client/BotLogic/Sleep/SleepingLayer.cs
+++ b/Client/BotLogic/Sleep/SleepingLayer.cs
@@ -138,7 +138,7 @@ namespace QuestingBots.BotLogic.Sleep
                 return false;
             }
 
-            if (objectiveManager.IsQuestingAllowed || !objectiveManager.IsInitialized)
+            if (objectiveManager.IsQuestingAllowed || !objectiveManager.IsInitialQuestSelectionComplete)
             {
                 return true;
             }

--- a/Client/Components/BotIdentityData.cs
+++ b/Client/Components/BotIdentityData.cs
@@ -1,0 +1,183 @@
+﻿using Comfort.Common;
+using EFT;
+using EFT.Ballistics;
+using QuestingBots.Components.Spawning;
+using QuestingBots.Controllers;
+using QuestingBots.Helpers;
+using QuestingBots.Utils;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace QuestingBots.Components
+{
+    public class BotIdentityData : MonoBehaviour
+    {
+        private BotOwner _botOwner = null!;
+        private bool _initComplete = false;
+
+        public bool ActivationComplete { get; private set; } = false;
+        public BotType BotType { get; private set; } = BotType.Undetermined;
+
+        public static BotIdentityData GetBotIdentityData(BotOwner botOwner)
+        {
+            BotIdentityData botIdentityData = botOwner.gameObject.GetOrAddComponent<BotIdentityData>();
+            botIdentityData.Init(botOwner);
+
+            return botIdentityData;
+        }
+
+        public void Init(BotOwner botOwner)
+        {
+            if (_initComplete) return;
+
+            _botOwner = botOwner;
+
+            // Spread out the work to reduce the performance impact
+            StartCoroutine(activateBot());
+
+            _initComplete = true;
+        }
+
+        private IEnumerator activateBot()
+        {
+            registerBot();
+            yield return null;
+
+            registerBotComponents();
+            yield return null;
+
+            BotType = getBotType();
+            yield return null;
+
+            adjustEftBotCounts();
+            yield return null;
+
+            updateBotHostilities();
+            yield return null;
+
+            // Fix for bots getting stuck in Standby when enemy PMC's are near them
+            _botOwner.StandBy.CanDoStandBy = false;
+
+            ActivationComplete = true;
+        }
+
+        private void registerBot()
+        {
+            string roleName = _botOwner.Profile.Info.Settings.Role.ToString();
+            Singleton<LoggingUtil>.Instance.LogInfo("Initial spawn type for bot " + _botOwner.GetText() + ": " + roleName);
+
+            if (_botOwner.WillBeAPMC())
+            {
+                Controllers.BotRegistrationManager.RegisterPMC(_botOwner);
+            }
+            else if (_botOwner.WillBeABoss())
+            {
+                Controllers.BotRegistrationManager.RegisterBoss(_botOwner);
+            }
+
+            Controllers.BotRegistrationManager.WriteMessageForNewBotSpawn(_botOwner);
+
+            if (_botOwner.IsARegisteredPMC() || _botOwner.WillBeAPlayerScav())
+            {
+                registerBotAsHumanPlayer();
+            }
+        }
+
+        private void registerBotAsHumanPlayer()
+        {
+            if (!Singleton<ConfigUtil>.Instance.CurrentConfig.BotSpawns.Enabled)
+            {
+                return;
+            }
+
+            BotSpawner botSpawnerClass = Singleton<IBotGame>.Instance.BotsController.BotSpawner;
+
+            botSpawnerClass.AddPlayer(_botOwner.GetPlayer());
+            _botOwner.GetPlayer().OnPlayerDead += deletePlayer;
+        }
+
+        private static void deletePlayer(Player player, IPlayer lastAgressor, DamageInfo damage, EBodyPart part)
+        {
+            BotSpawner botSpawnerClass = Singleton<IBotGame>.Instance.BotsController.BotSpawner;
+
+            try
+            {
+                botSpawnerClass.DeletePlayer(player.GetPlayer());
+            }
+            catch (Exception ex)
+            {
+                Singleton<LoggingUtil>.Instance.LogError("Could not delete player " + player.GetText() + ": " + ex.Message);
+                Singleton<LoggingUtil>.Instance.LogError(ex.StackTrace);
+            }
+        }
+
+        private void registerBotComponents()
+        {
+            Singleton<GameWorld>.Instance.GetComponent<Components.DebugData>().RegisterBot(_botOwner);
+
+            BotLogic.HiveMind.BotHiveMindMonitor.RegisterBot(_botOwner);
+            if (!BotLogic.HiveMind.BotHiveMindMonitor.IsRegistered(_botOwner))
+            {
+                Singleton<LoggingUtil>.Instance.LogError("Could not register " + _botOwner.GetText() + " in BotHiveMindMonitor");
+            }
+        }
+
+        private BotType getBotType()
+        {
+            return Controllers.BotRegistrationManager.GetBotType(_botOwner);
+        }
+
+        private void adjustEftBotCounts()
+        {
+            if (BotGenerator.GetAllGeneratedBotProfileIDs().Contains(_botOwner.Profile.Id))
+            {
+                reduceBotCounts();
+            }
+        }
+
+        private void updateBotHostilities()
+        {
+            if (shouldMakeBotGroupHostileTowardAllBosses())
+            {
+                Controllers.BotRegistrationManager.MakeBotGroupHostileTowardAllBosses(_botOwner);
+            }
+        }
+
+        private bool shouldMakeBotGroupHostileTowardAllBosses()
+        {
+            BotType botType = Controllers.BotRegistrationManager.GetBotType(_botOwner);
+
+            float chance = Singleton<ConfigUtil>.Instance.CurrentConfig.ChanceOfBeingHostileTowardBosses.GetValue(botType) ?? 0;
+
+            System.Random random = new System.Random();
+            if (random.Next(1, 100) <= chance)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private void reduceBotCounts()
+        {
+            Singleton<LoggingUtil>.Instance.LogDebug("Adjusting EFT bot counts for " + _botOwner.GetText() + "...");
+
+            BotSpawner botSpawnerClass = Singleton<IBotGame>.Instance.BotsController.BotSpawner;
+
+            if (_botOwner.Profile.Info.Settings.IsFollower())
+            {
+                botSpawnerClass._followersBotsCount--;
+            }
+            else if (_botOwner.Profile.Info.Settings.IsBoss())
+            {
+                botSpawnerClass._bossBotsCount--;
+            }
+
+            botSpawnerClass._allBotsCount--;
+        }
+    }
+}

--- a/Client/Components/BotIdentityData.cs
+++ b/Client/Components/BotIdentityData.cs
@@ -133,7 +133,8 @@ namespace QuestingBots.Components
 
         private void adjustEftBotCounts()
         {
-            if (BotGenerator.GetAllGeneratedBotProfileIDs().Contains(_botOwner.Profile.Id))
+            IEnumerable<string> allGeneratedBotProfileIds = Singleton<GameWorld>.Instance.GetComponent<BotGenerationManager>().GetAllGeneratedBotProfileIDs();
+            if (allGeneratedBotProfileIds.Contains(_botOwner.Profile.Id))
             {
                 reduceBotCounts();
             }

--- a/Client/Components/BotIdentityData.cs
+++ b/Client/Components/BotIdentityData.cs
@@ -5,6 +5,7 @@ using QuestingBots.Components.Spawning;
 using QuestingBots.Controllers;
 using QuestingBots.Helpers;
 using QuestingBots.Utils;
+using QuestingBots.Utils.Benchmarking;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -36,7 +37,6 @@ namespace QuestingBots.Components
 
             _botOwner = botOwner;
 
-            // Spread out the work to reduce the performance impact
             StartCoroutine(activateBot());
 
             _initComplete = true;
@@ -44,6 +44,9 @@ namespace QuestingBots.Components
 
         private IEnumerator activateBot()
         {
+            // Spread out the work to reduce the performance impact
+            yield return null;
+
             registerBot();
             yield return null;
 
@@ -51,13 +54,8 @@ namespace QuestingBots.Components
             yield return null;
 
             BotType = getBotType();
-            yield return null;
-
             adjustEftBotCounts();
-            yield return null;
-
             updateBotHostilities();
-            yield return null;
 
             // Fix for bots getting stuck in Standby when enemy PMC's are near them
             _botOwner.StandBy.CanDoStandBy = false;
@@ -65,6 +63,7 @@ namespace QuestingBots.Components
             ActivationComplete = true;
         }
 
+        [Benchmark]
         private void registerBot()
         {
             string roleName = _botOwner.Profile.Info.Settings.Role.ToString();
@@ -96,8 +95,9 @@ namespace QuestingBots.Components
 
             BotSpawner botSpawnerClass = Singleton<IBotGame>.Instance.BotsController.BotSpawner;
 
-            botSpawnerClass.AddPlayer(_botOwner.GetPlayer());
-            _botOwner.GetPlayer().OnPlayerDead += deletePlayer;
+            Player player = _botOwner.GetPlayer();
+            botSpawnerClass.AddPlayer(player);
+            player.OnPlayerDead += deletePlayer;
         }
 
         private static void deletePlayer(Player player, IPlayer lastAgressor, DamageInfo damage, EBodyPart part)
@@ -106,7 +106,7 @@ namespace QuestingBots.Components
 
             try
             {
-                botSpawnerClass.DeletePlayer(player.GetPlayer());
+                botSpawnerClass.DeletePlayer(player);
             }
             catch (Exception ex)
             {
@@ -115,6 +115,7 @@ namespace QuestingBots.Components
             }
         }
 
+        [Benchmark]
         private void registerBotComponents()
         {
             Singleton<GameWorld>.Instance.GetComponent<Components.DebugData>().RegisterBot(_botOwner);
@@ -140,29 +141,6 @@ namespace QuestingBots.Components
             }
         }
 
-        private void updateBotHostilities()
-        {
-            if (shouldMakeBotGroupHostileTowardAllBosses())
-            {
-                Controllers.BotRegistrationManager.MakeBotGroupHostileTowardAllBosses(_botOwner);
-            }
-        }
-
-        private bool shouldMakeBotGroupHostileTowardAllBosses()
-        {
-            BotType botType = Controllers.BotRegistrationManager.GetBotType(_botOwner);
-
-            float chance = Singleton<ConfigUtil>.Instance.CurrentConfig.ChanceOfBeingHostileTowardBosses.GetValue(botType) ?? 0;
-
-            System.Random random = new System.Random();
-            if (random.Next(1, 100) <= chance)
-            {
-                return true;
-            }
-
-            return false;
-        }
-
         private void reduceBotCounts()
         {
             Singleton<LoggingUtil>.Instance.LogDebug("Adjusting EFT bot counts for " + _botOwner.GetText() + "...");
@@ -179,6 +157,27 @@ namespace QuestingBots.Components
             }
 
             botSpawnerClass._allBotsCount--;
+        }
+
+        private void updateBotHostilities()
+        {
+            if (shouldMakeBotGroupHostileTowardAllBosses())
+            {
+                Controllers.BotRegistrationManager.MakeBotGroupHostileTowardAllBosses(_botOwner);
+            }
+        }
+
+        private bool shouldMakeBotGroupHostileTowardAllBosses()
+        {
+            float chance = Singleton<ConfigUtil>.Instance.CurrentConfig.ChanceOfBeingHostileTowardBosses.GetValue(BotType) ?? 0;
+
+            System.Random random = new System.Random();
+            if (random.Next(1, 100) <= chance)
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/Client/Components/BotIdentityData.cs
+++ b/Client/Components/BotIdentityData.cs
@@ -44,10 +44,14 @@ namespace QuestingBots.Components
 
         private IEnumerator activateBot()
         {
+            string roleName = _botOwner.Profile.Info.Settings.Role.ToString();
+            Singleton<LoggingUtil>.Instance.LogInfo("Initial spawn type for bot " + _botOwner.GetText() + ": " + roleName);
+
             // Spread out the work to reduce the performance impact
             yield return null;
 
             registerBot();
+            Controllers.BotRegistrationManager.WriteMessageForNewBotSpawn(_botOwner);
             yield return null;
 
             registerBotComponents();
@@ -66,9 +70,6 @@ namespace QuestingBots.Components
         [Benchmark]
         private void registerBot()
         {
-            string roleName = _botOwner.Profile.Info.Settings.Role.ToString();
-            Singleton<LoggingUtil>.Instance.LogInfo("Initial spawn type for bot " + _botOwner.GetText() + ": " + roleName);
-
             if (_botOwner.WillBeAPMC())
             {
                 Controllers.BotRegistrationManager.RegisterPMC(_botOwner);
@@ -77,8 +78,6 @@ namespace QuestingBots.Components
             {
                 Controllers.BotRegistrationManager.RegisterBoss(_botOwner);
             }
-
-            Controllers.BotRegistrationManager.WriteMessageForNewBotSpawn(_botOwner);
 
             if (_botOwner.IsARegisteredPMC() || _botOwner.WillBeAPlayerScav())
             {
@@ -93,10 +92,8 @@ namespace QuestingBots.Components
                 return;
             }
 
-            BotSpawner botSpawnerClass = Singleton<IBotGame>.Instance.BotsController.BotSpawner;
-
             Player player = _botOwner.GetPlayer();
-            botSpawnerClass.AddPlayer(player);
+            Singleton<IBotGame>.Instance.BotsController.BotSpawner.AddPlayer(player);
             player.OnPlayerDead += deletePlayer;
         }
 
@@ -115,16 +112,10 @@ namespace QuestingBots.Components
             }
         }
 
-        [Benchmark]
         private void registerBotComponents()
         {
             Singleton<GameWorld>.Instance.GetComponent<Components.DebugData>().RegisterBot(_botOwner);
-
             BotLogic.HiveMind.BotHiveMindMonitor.RegisterBot(_botOwner);
-            if (!BotLogic.HiveMind.BotHiveMindMonitor.IsRegistered(_botOwner))
-            {
-                Singleton<LoggingUtil>.Instance.LogError("Could not register " + _botOwner.GetText() + " in BotHiveMindMonitor");
-            }
         }
 
         private BotType getBotType()

--- a/Client/Components/BotObjectiveManager.cs
+++ b/Client/Components/BotObjectiveManager.cs
@@ -165,7 +165,11 @@ namespace QuestingBots.Components
                     Singleton<LoggingUtil>.Instance.LogError("Could not determine bot type for " + botOwner.GetText() + " (Brain type: " + botOwner.Brain.BaseBrain.ShortName() + ")");
                 }
 
-                QuestSelector.NewJobCreationJobRunning();
+                if (IsQuestingAllowed)
+                {
+                    QuestSelector.RefreshJobAssignment();
+                }
+
                 IsInitialQuestSelectionComplete = true;
                 return;
             }
@@ -224,7 +228,7 @@ namespace QuestingBots.Components
                 return;
             }
 
-            QuestSelector.GetCurrentJobAssignment();
+            QuestSelector.RefreshJobAssignment();
         }
 
         public BotJobAssignment CloneCurrentJobAssignment(BotOwner otherBotToDoAssignment)
@@ -305,18 +309,19 @@ namespace QuestingBots.Components
 
         public bool TryChangeObjective()
         {
-            double? timeSinceJobEnded = assignment?.TimeSinceEnded();
-            if (timeSinceJobEnded.HasValue && (timeSinceJobEnded.Value < Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.MinTimeBetweenSwitchingObjectives))
-            {
-                return false;
-            }
-
-            assignment?.Inactivate();
-
             if (botOwner == null)
             {
                 return false;
             }
+
+            double? timeSinceJobEnded = assignment?.TimeSinceEnded();
+            if (timeSinceJobEnded.HasValue && (timeSinceJobEnded.Value < Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.MinTimeBetweenSwitchingObjectives))
+            {
+                Singleton<LoggingUtil>.Instance.LogWarning("Could not change the job assignment for " + botOwner.GetText() + " because not enough time has elapsed since it was last updated");
+                return false;
+            }
+
+            assignment?.Inactivate();
 
             return QuestSelector.TryCreateNewJobAssignment();
         }

--- a/Client/Components/BotObjectiveManager.cs
+++ b/Client/Components/BotObjectiveManager.cs
@@ -27,6 +27,7 @@ namespace QuestingBots.Components
         public float PauseRequest { get; set; } = 0;
         public Models.BotSprintingController BotSprintingController { get; private set; } = null!;
         public BotLogic.BotMonitor.BotMonitorController BotMonitor { get; private set; } = null!;
+        public BotIdentityData IdentityData { get; private set; } = null!;
         public BotPathData BotPath { get; private set; } = null!;
         public EFT.Interactive.Door DoorToOpen { get; set; } = null!;
         public Vector3? LastCorner { get; set; } = null;
@@ -101,6 +102,11 @@ namespace QuestingBots.Components
                 BotMonitor.Init(botOwner);
             }
 
+            if (IdentityData == null)
+            {
+                IdentityData = BotIdentityData.GetBotIdentityData(botOwner);
+            }
+
             if (BotPath == null)
             {
                 BotPath = new BotPathData(botOwner);
@@ -113,40 +119,6 @@ namespace QuestingBots.Components
 
             // Override the EFT distance that makes bots "avoid danger" when the BTR is near
             botOwner.Settings.FileSettings.Mind.AVOID_BTR_RADIUS_SQR = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BTRRunDistance * Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BTRRunDistance;
-        }
-
-        private void updateBotType()
-        {
-            if (!BotLogic.HiveMind.BotHiveMindMonitor.IsRegistered(botOwner))
-            {
-                Singleton<LoggingUtil>.Instance.LogError(botOwner.GetText() + " has not been registered in BotHiveMindMonitor");
-            }
-
-            BotType botType = Controllers.BotRegistrationManager.GetBotType(botOwner);
-
-            if ((botType == BotType.PMC) && Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.AllowedBotTypesForQuesting.PMC)
-            {
-                IsQuestingAllowed = true;
-            }
-            if ((botType == BotType.Boss) && Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.AllowedBotTypesForQuesting.Boss)
-            {
-                IsQuestingAllowed = true;
-            }
-            if ((botType == BotType.Scav) && Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.AllowedBotTypesForQuesting.Scav)
-            {
-                IsQuestingAllowed = true;
-            }
-            if ((botType == BotType.PScav) && Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.AllowedBotTypesForQuesting.PScav)
-            {
-                IsQuestingAllowed = true;
-            }
-
-            if (botType == BotType.Undetermined)
-            {
-                Singleton<LoggingUtil>.Instance.LogError("Could not determine bot type for " + botOwner.GetText() + " (Brain type: " + botOwner.Brain.BaseBrain.ShortName() + ")");
-            }
-
-            IsInitialized = true;
         }
 
         protected void Update()
@@ -169,9 +141,20 @@ namespace QuestingBots.Components
 
             if (!IsInitialized)
             {
-                updateBotType();
+                if (!IdentityData.ActivationComplete)
+                {
+                    return;
+                }
+
+                IsQuestingAllowed = IdentityData.BotType.AllowsQuesting();
+                if (IdentityData.BotType == BotType.Undetermined)
+                {
+                    Singleton<LoggingUtil>.Instance.LogError("Could not determine bot type for " + botOwner.GetText() + " (Brain type: " + botOwner.Brain.BaseBrain.ShortName() + ")");
+                }
+
                 setInitialObjective();
 
+                IsInitialized = true;
                 return;
             }
 

--- a/Client/Components/BotObjectiveManager.cs
+++ b/Client/Components/BotObjectiveManager.cs
@@ -234,7 +234,7 @@ namespace QuestingBots.Components
         public BotJobAssignment CloneCurrentJobAssignment(BotOwner otherBotToDoAssignment)
         {
             BotJobAssignment clonedAssignment = new BotJobAssignment(otherBotToDoAssignment, assignment);
-            BotJobAssignmentFactory.Register(clonedAssignment);
+            BotJobAssignmentController.Register(clonedAssignment);
 
             return clonedAssignment;
         }

--- a/Client/Components/BotObjectiveManager.cs
+++ b/Client/Components/BotObjectiveManager.cs
@@ -131,6 +131,11 @@ namespace QuestingBots.Components
                 return;
             }
 
+            if ((botOwner.BotState != EBotState.Active) || botOwner.IsDead)
+            {
+                return;
+            }
+
             if (!IsInitialized)
             {
                 Singleton<LoggingUtil>.Instance.LogDebug("Waiting for BotObjectiveManager initialization to finish...");
@@ -160,12 +165,7 @@ namespace QuestingBots.Components
                     Singleton<LoggingUtil>.Instance.LogError("Could not determine bot type for " + botOwner.GetText() + " (Brain type: " + botOwner.Brain.BaseBrain.ShortName() + ")");
                 }
 
-                BotJobAssignment? initialJobAssignment = QuestSelector.GetInitialObjective();
-                if (initialJobAssignment != null)
-                {
-                    SetObjective(initialJobAssignment);
-                }
-
+                QuestSelector.NewJobCreationJobRunning();
                 IsInitialQuestSelectionComplete = true;
                 return;
             }
@@ -175,9 +175,13 @@ namespace QuestingBots.Components
                 return;
             }
 
-            if ((botOwner.BotState != EBotState.Active) || botOwner.IsDead)
+            if (QuestSelector.NewAssignmentReady)
             {
-                return;
+                BotJobAssignment? botJobAssignment = QuestSelector.GetCurrentJobAssignment();
+                if (botJobAssignment != null)
+                {
+                    SetObjective(botJobAssignment);
+                }
             }
 
             bool isSleeping = BotRegistrationManager.IsBotSleeping(botOwner.Profile.Id);
@@ -220,11 +224,7 @@ namespace QuestingBots.Components
                 return;
             }
 
-            BotJobAssignment? botJobAssignment = QuestSelector.GetCurrentJobAssignment();
-            if (botJobAssignment != null)
-            {
-                SetObjective(botJobAssignment);
-            }
+            QuestSelector.GetCurrentJobAssignment();
         }
 
         public BotJobAssignment CloneCurrentJobAssignment(BotOwner otherBotToDoAssignment)
@@ -245,8 +245,24 @@ namespace QuestingBots.Components
             lastAssignment = assignment;
             assignment = objective;
 
-            //Singleton<LoggingUtil>.Instance.LogInfo("Updated objective for " + botOwner.GetText() + " from " + (lastAssignment?.ToString() ?? "[None]") + " to " + assignment.ToString());
+            Singleton<LoggingUtil>.Instance.LogInfo("Bot " + botOwner.GetText() + " is now doing " + assignment.ToString());
 
+            if (lastAssignment != null)
+            {
+                Singleton<LoggingUtil>.Instance.LogDebug("Bot " + botOwner.GetText() + " was previously doing " + lastAssignment.ToString());
+            }
+
+            //double? timeSinceBotStartedQuest = lastAssignment.QuestAssignment.ElapsedTimeSinceBotStarted(bot);
+            //double? timeSinceBotLastFinishedQuest = lastAssignment.QuestAssignment.ElapsedTimeWhenLastEndedForBot(bot);
+            //string startedTimeText = timeSinceBotStartedQuest.HasValue ? timeSinceBotStartedQuest.Value.ToString() : "N/A";
+            //string lastFinishedTimeText = timeSinceBotLastFinishedQuest.HasValue ? timeSinceBotLastFinishedQuest.Value.ToString() : "N/A";
+            //Singleton<LoggingUtil>.Instance.LogInfo("Time since first objective ended: " + startedTimeText + ", Time since last objective ended: " + lastFinishedTimeText);
+
+            CheckIfQuestAssignmentIsOnLightkeeperIsland();
+        }
+
+        private void CheckIfQuestAssignmentIsOnLightkeeperIsland()
+        {
             if (!Singleton<GameWorld>.Instance.TryGetComponent(out Components.LightkeeperIslandMonitor lightkeeperIslandMonitor))
             {
                 return;
@@ -256,8 +272,6 @@ namespace QuestingBots.Components
             {
                 Singleton<LoggingUtil>.Instance.LogInfo(botOwner.GetText() + "'s new quest assignment is on Lightkeeper Island");
             }
-
-            Singleton<LoggingUtil>.Instance.LogInfo("Bot " + botOwner.GetText() + " is now doing " + assignment.ToString());
         }
 
         public void CompleteObjective()
@@ -304,14 +318,7 @@ namespace QuestingBots.Components
                 return false;
             }
 
-            BotJobAssignment? botJobAssignment = QuestSelector.GetNewBotJobAssignment();
-            if (botJobAssignment == null)
-            {
-                return false;
-            }
-            
-            SetObjective(botJobAssignment);
-            return true;
+            return QuestSelector.TryCreateNewJobAssignment();
         }
 
         public void UnlockDoor(EFT.Interactive.WorldInteractiveObject door)

--- a/Client/Components/BotObjectiveManager.cs
+++ b/Client/Components/BotObjectiveManager.cs
@@ -1,6 +1,5 @@
 ﻿using Comfort.Common;
 using EFT;
-using EFT.Interactive;
 using QuestingBots.BotLogic.BotMonitor.Monitors;
 using QuestingBots.BotLogic.HiveMind;
 using QuestingBots.Controllers;
@@ -22,12 +21,14 @@ namespace QuestingBots.Components
     public class BotObjectiveManager : BehaviorExtensions.MonoBehaviourDelayedUpdate
     {
         public bool IsInitialized { get; private set; } = false;
+        public bool IsInitialQuestSelectionComplete { get; private set; } = false;
         public bool IsQuestingAllowed { get; private set; } = false;
         public int StuckCount { get; set; } = 0;
         public float PauseRequest { get; set; } = 0;
         public Models.BotSprintingController BotSprintingController { get; private set; } = null!;
         public BotLogic.BotMonitor.BotMonitorController BotMonitor { get; private set; } = null!;
         public BotIdentityData IdentityData { get; private set; } = null!;
+        public BotQuestSelector QuestSelector { get; private set; } = null!;
         public BotPathData BotPath { get; private set; } = null!;
         public EFT.Interactive.Door DoorToOpen { get; set; } = null!;
         public Vector3? LastCorner { get; set; } = null;
@@ -35,7 +36,6 @@ namespace QuestingBots.Components
         private BotOwner botOwner = null!;
         private BotJobAssignment assignment = null!;
         private BotJobAssignment lastAssignment = null!;
-        private ExfiltrationPoint exfiltrationPoint = null!;
         private Stopwatch timeSpentAtObjectiveTimer = new Stopwatch();
         private Components.BotQuestBuilder botQuestBuilder = null!;
 
@@ -107,18 +107,20 @@ namespace QuestingBots.Components
                 IdentityData = BotIdentityData.GetBotIdentityData(botOwner);
             }
 
+            if (QuestSelector == null)
+            {
+                QuestSelector = BotQuestSelector.GetBotQuestSelector(botOwner);
+            }
+
             if (BotPath == null)
             {
                 BotPath = new BotPathData(botOwner);
             }
 
-            if (exfiltrationPoint == null)
-            {
-                SetExfiliationPointForQuesting();
-            }
-
             // Override the EFT distance that makes bots "avoid danger" when the BTR is near
             botOwner.Settings.FileSettings.Mind.AVOID_BTR_RADIUS_SQR = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BTRRunDistance * Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BTRRunDistance;
+
+            IsInitialized = true;
         }
 
         protected void Update()
@@ -126,6 +128,12 @@ namespace QuestingBots.Components
             // Fix for this component not being destroyed when raids end. This can happen when exceptions are ignored while destroying bots.
             if (!Singleton<GameWorld>.Instantiated)
             {
+                return;
+            }
+
+            if (!IsInitialized)
+            {
+                Singleton<LoggingUtil>.Instance.LogDebug("Waiting for BotObjectiveManager initialization to finish...");
                 return;
             }
 
@@ -139,7 +147,7 @@ namespace QuestingBots.Components
                 return;
             }
 
-            if (!IsInitialized)
+            if (!IsInitialQuestSelectionComplete)
             {
                 if (!IdentityData.ActivationComplete)
                 {
@@ -152,9 +160,13 @@ namespace QuestingBots.Components
                     Singleton<LoggingUtil>.Instance.LogError("Could not determine bot type for " + botOwner.GetText() + " (Brain type: " + botOwner.Brain.BaseBrain.ShortName() + ")");
                 }
 
-                setInitialObjective();
+                BotJobAssignment? initialJobAssignment = QuestSelector.GetInitialObjective();
+                if (initialJobAssignment != null)
+                {
+                    SetObjective(initialJobAssignment);
+                }
 
-                IsInitialized = true;
+                IsInitialQuestSelectionComplete = true;
                 return;
             }
 
@@ -195,28 +207,30 @@ namespace QuestingBots.Components
             }
 
             bool? hasWaitedLongEnough = assignment?.HasWaitedLongEnoughAfterEnding();
-            if (hasWaitedLongEnough.HasValue && hasWaitedLongEnough.Value)
+            if (hasWaitedLongEnough != true)
             {
-                if (botOwner.NumberOfConsecutiveFailedAssignments() >= Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.StuckBotDetection.MaxCount)
-                {
-                    Singleton<LoggingUtil>.Instance.LogWarning(botOwner.GetText() + " has failed too many consecutive assignments and is no longer allowed to quest.");
-                    botOwner.Mover.Stop();
-                    IsQuestingAllowed = false;
-                    return;
-                }
+                return;
+            }
 
-                BotJobAssignment? botJobAssignment = botOwner.GetCurrentJobAssignment();
-                if (botJobAssignment != null)
-                {
-                    SetObjective(botJobAssignment);
-                }
+            if (botOwner.NumberOfConsecutiveFailedAssignments() >= Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.StuckBotDetection.MaxCount)
+            {
+                Singleton<LoggingUtil>.Instance.LogWarning(botOwner.GetText() + " has failed too many consecutive assignments and is no longer allowed to quest.");
+                botOwner.Mover.Stop();
+                IsQuestingAllowed = false;
+                return;
+            }
+
+            BotJobAssignment? botJobAssignment = QuestSelector.GetCurrentJobAssignment();
+            if (botJobAssignment != null)
+            {
+                SetObjective(botJobAssignment);
             }
         }
 
         public BotJobAssignment CloneCurrentJobAssignment(BotOwner otherBotToDoAssignment)
         {
             BotJobAssignment clonedAssignment = new BotJobAssignment(otherBotToDoAssignment, assignment);
-            BotJobAssignmentFactory.RegisterBotJobAssignment(clonedAssignment);
+            BotJobAssignmentFactory.Register(clonedAssignment);
 
             return clonedAssignment;
         }
@@ -242,6 +256,8 @@ namespace QuestingBots.Components
             {
                 Singleton<LoggingUtil>.Instance.LogInfo(botOwner.GetText() + "'s new quest assignment is on Lightkeeper Island");
             }
+
+            Singleton<LoggingUtil>.Instance.LogInfo("Bot " + botOwner.GetText() + " is now doing " + assignment.ToString());
         }
 
         public void CompleteObjective()
@@ -288,9 +304,13 @@ namespace QuestingBots.Components
                 return false;
             }
 
-            SetObjective(botOwner.GetNewBotJobAssignment());
-            Singleton<LoggingUtil>.Instance.LogInfo("Bot " + botOwner.GetText() + " is now doing " + (assignment?.ToString() ?? "[NULL]"));
-
+            BotJobAssignment? botJobAssignment = QuestSelector.GetNewBotJobAssignment();
+            if (botJobAssignment == null)
+            {
+                return false;
+            }
+            
+            SetObjective(botJobAssignment);
             return true;
         }
 
@@ -423,67 +443,6 @@ namespace QuestingBots.Components
                 case LootAfterCompleting.Inhibit:
                     BotMonitor.GetMonitor<BotLootingMonitor>().TryPreventBotFromLooting(duration);
                     break;
-            }
-        }
-
-        public void SetExfiliationPointForQuesting()
-        {
-            Dictionary<ExfiltrationPoint, float> exfiltrationPointDistances = Singleton<GameWorld>.Instance.ExfiltrationController.ExfiltrationPoints
-                .ToDictionary(p => p, p => Vector3.Distance(p.transform.position, botOwner.Position));
-
-            if (exfiltrationPointDistances.Count > 0)
-            {
-                KeyValuePair<ExfiltrationPoint, float> furthestPoint = exfiltrationPointDistances
-                    .OrderBy(p => p.Value)
-                    .Last();
-
-                exfiltrationPoint = furthestPoint.Key;
-
-                //Singleton<LoggingUtil>.Instance.LogInfo(botOwner.GetText() + " has selected " + furthestPoint.Key.Settings.Name + " as its furthest exfil point (" + furthestPoint.Value + "m)");
-            }
-        }
-
-        public float? DistanceToExfiltrationPointForQuesting()
-        {
-            if (exfiltrationPoint == null)
-            {
-                return null;
-            }
-
-            return Vector3.Distance(botOwner.Position, exfiltrationPoint.transform.position);
-        }
-
-        public Vector3? VectorToExfiltrationPointForQuesting()
-        {
-            if (exfiltrationPoint == null)
-            {
-                return null;
-            }
-
-            return exfiltrationPoint.transform.position - botOwner.Position;
-        }
-
-        [Benchmark]
-        private void setInitialObjective()
-        {
-            // Only set an objective for the bot if its type is allowed to spawn and all quests have been loaded and generated
-            if (!IsQuestingAllowed || !Singleton<GameWorld>.Instance.GetComponent<Components.BotQuestBuilder>().HaveQuestsBeenBuilt)
-            {
-                return;
-            }
-
-            Singleton<LoggingUtil>.Instance.LogInfo("Setting objective for " + botOwner.GetText() + " (Brain type: " + botOwner.Brain.BaseBrain.ShortName() + ")...");
-            try
-            {
-                BotJobAssignment? botJobAssignment = botOwner.GetCurrentJobAssignment();
-                if (botJobAssignment != null)
-                {
-                    SetObjective(botJobAssignment);
-                }
-            }
-            catch (TimeoutException)
-            {
-                Singleton<LoggingUtil>.Instance.LogError("Timed out when trying to select an initial objective for " + botOwner.GetText());
             }
         }
     }

--- a/Client/Components/BotObjectiveManager.cs
+++ b/Client/Components/BotObjectiveManager.cs
@@ -1,5 +1,6 @@
 ﻿using Comfort.Common;
 using EFT;
+using QuestingBots.BotLogic.BotMonitor;
 using QuestingBots.BotLogic.BotMonitor.Monitors;
 using QuestingBots.BotLogic.HiveMind;
 using QuestingBots.Controllers;
@@ -26,10 +27,10 @@ namespace QuestingBots.Components
         public int StuckCount { get; set; } = 0;
         public float PauseRequest { get; set; } = 0;
         public Models.BotSprintingController BotSprintingController { get; private set; } = null!;
+        public BotPathData BotPath { get; private set; } = null!;
         public BotLogic.BotMonitor.BotMonitorController BotMonitor { get; private set; } = null!;
         public BotIdentityData IdentityData { get; private set; } = null!;
         public BotQuestSelector QuestSelector { get; private set; } = null!;
-        public BotPathData BotPath { get; private set; } = null!;
         public EFT.Interactive.Door DoorToOpen { get; set; } = null!;
         public Vector3? LastCorner { get; set; } = null;
 
@@ -91,34 +92,15 @@ namespace QuestingBots.Components
             base.UpdateInterval = 200;
             botOwner = _botOwner;
 
-            if (BotSprintingController == null)
-            {
-                BotSprintingController = new Models.BotSprintingController(botOwner);
-            }
-
-            if (BotMonitor == null)
-            {
-                BotMonitor = botOwner.GetPlayer.gameObject.GetOrAddComponent<BotLogic.BotMonitor.BotMonitorController>();
-                BotMonitor.Init(botOwner);
-            }
-
-            if (IdentityData == null)
-            {
-                IdentityData = BotIdentityData.GetBotIdentityData(botOwner);
-            }
-
-            if (QuestSelector == null)
-            {
-                QuestSelector = BotQuestSelector.GetBotQuestSelector(botOwner);
-            }
-
-            if (BotPath == null)
-            {
-                BotPath = new BotPathData(botOwner);
-            }
-
+            BotSprintingController = new Models.BotSprintingController(botOwner);
+            BotPath = new BotPathData(botOwner);
+            BotMonitor = BotMonitorController.GetBotMonitorController(botOwner);
+            IdentityData = BotIdentityData.GetBotIdentityData(botOwner);
+            QuestSelector = BotQuestSelector.GetBotQuestSelector(botOwner);
+            
             // Override the EFT distance that makes bots "avoid danger" when the BTR is near
-            botOwner.Settings.FileSettings.Mind.AVOID_BTR_RADIUS_SQR = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BTRRunDistance * Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BTRRunDistance;
+            float newAvoidBtrRadiusSqr = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BTRRunDistance * Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BTRRunDistance;
+            botOwner.Settings.FileSettings.Mind.AVOID_BTR_RADIUS_SQR = newAvoidBtrRadiusSqr;
 
             IsInitialized = true;
         }
@@ -142,41 +124,36 @@ namespace QuestingBots.Components
                 return;
             }
 
-            if ((botQuestBuilder == null) && !Singleton<GameWorld>.Instance.TryGetComponent(out botQuestBuilder))
-            {
-                return;
-            }
-
-            if (!botQuestBuilder.HaveQuestsBeenBuilt)
-            {
-                return;
-            }
-
             if (!IsInitialQuestSelectionComplete)
             {
-                if (!IdentityData.ActivationComplete)
-                {
-                    return;
-                }
-
-                IsQuestingAllowed = IdentityData.BotType.AllowsQuesting();
-                if (IdentityData.BotType == BotType.Undetermined)
-                {
-                    Singleton<LoggingUtil>.Instance.LogError("Could not determine bot type for " + botOwner.GetText() + " (Brain type: " + botOwner.Brain.BaseBrain.ShortName() + ")");
-                }
-
-                if (IsQuestingAllowed)
-                {
-                    QuestSelector.RefreshJobAssignment();
-                }
-
-                IsInitialQuestSelectionComplete = true;
+                SetInitialQuest();
                 return;
             }
 
             if (!IsQuestingAllowed)
             {
                 return;
+            }
+
+            if (BotRegistrationManager.IsBotSleeping(botOwner.Profile.Id))
+            {
+                timeSpentAtObjectiveTimer.Stop();
+                return;
+            }
+
+            // Don't allow expensive parts of this behavior (selecting an objective) to run too often
+            if (!canUpdate())
+            {
+                return;
+            }
+
+            if (IsCloseToObjective())
+            {
+                timeSpentAtObjectiveTimer.Start();
+            }
+            else
+            {
+                timeSpentAtObjectiveTimer.Reset();
             }
 
             if (QuestSelector.NewAssignmentReady)
@@ -186,26 +163,6 @@ namespace QuestingBots.Components
                 {
                     SetObjective(botJobAssignment);
                 }
-            }
-
-            bool isSleeping = BotRegistrationManager.IsBotSleeping(botOwner.Profile.Id);
-            if (isSleeping)
-            {
-                timeSpentAtObjectiveTimer.Stop();
-            }
-            else if (IsCloseToObjective())
-            {
-                timeSpentAtObjectiveTimer.Start();
-            }
-            else
-            {
-                timeSpentAtObjectiveTimer.Reset();
-            }
-
-            // Don't allow expensive parts of this behavior (selecting an objective) to run too often
-            if (isSleeping || !canUpdate())
-            {
-                return;
             }
 
             // Don't monitor the bot's job assignment if it's a follower of a boss
@@ -231,6 +188,37 @@ namespace QuestingBots.Components
             QuestSelector.RefreshJobAssignment();
         }
 
+        private void SetInitialQuest()
+        {
+            if (!IdentityData.ActivationComplete)
+            {
+                return;
+            }
+
+            if ((botQuestBuilder == null) && !Singleton<GameWorld>.Instance.TryGetComponent(out botQuestBuilder))
+            {
+                return;
+            }
+
+            if (!botQuestBuilder.HaveQuestsBeenBuilt)
+            {
+                return;
+            }
+
+            IsQuestingAllowed = IdentityData.BotType.AllowsQuesting();
+            if (IdentityData.BotType == BotType.Undetermined)
+            {
+                Singleton<LoggingUtil>.Instance.LogError("Could not determine bot type for " + botOwner.GetText() + " (Brain type: " + botOwner.Brain.BaseBrain.ShortName() + ")");
+            }
+
+            if (IsQuestingAllowed)
+            {
+                QuestSelector.RefreshJobAssignment();
+            }
+
+            IsInitialQuestSelectionComplete = true;
+        }
+
         public BotJobAssignment CloneCurrentJobAssignment(BotOwner otherBotToDoAssignment)
         {
             BotJobAssignment clonedAssignment = new BotJobAssignment(otherBotToDoAssignment, assignment);
@@ -249,7 +237,14 @@ namespace QuestingBots.Components
             lastAssignment = assignment;
             assignment = objective;
 
-            Singleton<LoggingUtil>.Instance.LogInfo("Bot " + botOwner.GetText() + " is now doing " + assignment.ToString());
+            if (assignment != null)
+            {
+                Singleton<LoggingUtil>.Instance.LogInfo("Bot " + botOwner.GetText() + " is now doing " + assignment.ToString());
+            }
+            else
+            {
+                Singleton<LoggingUtil>.Instance.LogWarning("Bot " + botOwner.GetText() + " was given a null job assignment");
+            }
 
             if (lastAssignment != null)
             {

--- a/Client/Components/BotObjectiveManager.cs
+++ b/Client/Components/BotObjectiveManager.cs
@@ -24,6 +24,7 @@ namespace QuestingBots.Components
         public bool IsInitialized { get; private set; } = false;
         public bool IsInitialQuestSelectionComplete { get; private set; } = false;
         public bool IsQuestingAllowed { get; private set; } = false;
+        public BotJobAssignment? CurrentAssignment { get; private set; } = null;
         public int StuckCount { get; set; } = 0;
         public float PauseRequest { get; set; } = 0;
         public Models.BotSprintingController BotSprintingController { get; private set; } = null!;
@@ -35,28 +36,26 @@ namespace QuestingBots.Components
         public Vector3? LastCorner { get; set; } = null;
 
         private BotOwner botOwner = null!;
-        private BotJobAssignment assignment = null!;
-        private BotJobAssignment lastAssignment = null!;
+        private BotJobAssignment? lastAssignment = null;
         private Stopwatch timeSpentAtObjectiveTimer = new Stopwatch();
-        private Components.BotQuestBuilder botQuestBuilder = null!;
 
-        public Vector3? Position => assignment?.Position;
-        public Vector3? LookToPosition => assignment?.LookToPosition;
-        public Vector3? TargetPosition => assignment?.TargetPosition;
-        public bool IsJobAssignmentActive => assignment?.IsActive == true;
-        public bool HasTeleportingAssignment => assignment?.MustTeleport == true;
-        public bool HasCompletePath => assignment.HasCompletePath;
-        public string DoorIDToUnlockForObjective => assignment?.QuestObjectiveAssignment?.DoorIDToUnlock ?? "";
-        public Vector3? InteractionPositionForDoorToUnlockForObjective => assignment?.QuestObjectiveAssignment?.InteractionPositionToUnlockDoor?.ToUnityVector3();
-        public bool MustUnlockDoor => assignment?.DoorToUnlock != null;
-        public QuestAction CurrentQuestAction => assignment?.QuestObjectiveStepAssignment?.ActionType ?? QuestAction.Undefined;
-        public double MinElapsedActionTime => assignment?.MinElapsedTime ?? 0;
-        public float ChanceOfHavingKey => assignment?.QuestObjectiveStepAssignment?.ChanceOfHavingKey ?? 0;
-        public float? MaxDistanceForCurrentStep => assignment?.QuestObjectiveStepAssignment?.MaxDistance;
-        public bool IgnoreHearing => assignment?.IgnoreHearing ?? false;
-        public bool ForceUnlock => assignment?.ForceUnlock ?? false;
-        public bool PrioritizeQuestingOverFollowing => assignment?.PrioritizeOverFollowing ?? false;
-        public double? WaitTimeAfterCompleting => assignment?.QuestObjectiveStepAssignment?.WaitTimeAfterCompleting;
+        public Vector3? Position => CurrentAssignment?.Position;
+        public Vector3? LookToPosition => CurrentAssignment?.LookToPosition;
+        public Vector3? TargetPosition => CurrentAssignment?.TargetPosition;
+        public bool IsJobAssignmentActive => CurrentAssignment?.IsActive == true;
+        public bool HasTeleportingAssignment => CurrentAssignment?.MustTeleport == true;
+        public bool HasCompletePath => CurrentAssignment?.HasCompletePath ?? false;
+        public string DoorIDToUnlockForObjective => CurrentAssignment?.QuestObjectiveAssignment?.DoorIDToUnlock ?? "";
+        public Vector3? InteractionPositionForDoorToUnlockForObjective => CurrentAssignment?.QuestObjectiveAssignment?.InteractionPositionToUnlockDoor?.ToUnityVector3();
+        public bool MustUnlockDoor => CurrentAssignment?.DoorToUnlock != null;
+        public QuestAction CurrentQuestAction => CurrentAssignment?.QuestObjectiveStepAssignment?.ActionType ?? QuestAction.Undefined;
+        public double MinElapsedActionTime => CurrentAssignment?.MinElapsedTime ?? 0;
+        public float ChanceOfHavingKey => CurrentAssignment?.QuestObjectiveStepAssignment?.ChanceOfHavingKey ?? 0;
+        public float? MaxDistanceForCurrentStep => CurrentAssignment?.QuestObjectiveStepAssignment?.MaxDistance;
+        public bool IgnoreHearing => CurrentAssignment?.IgnoreHearing ?? false;
+        public bool ForceUnlock => CurrentAssignment?.ForceUnlock ?? false;
+        public bool PrioritizeQuestingOverFollowing => CurrentAssignment?.PrioritizeOverFollowing ?? false;
+        public double? WaitTimeAfterCompleting => CurrentAssignment?.QuestObjectiveStepAssignment?.WaitTimeAfterCompleting;
 
         public double TimeSpentAtObjective => timeSpentAtObjectiveTimer.ElapsedMilliseconds / 1000.0;
         public float DistanceToObjective => Position.HasValue ? Vector3.Distance(Position.Value, botOwner.Position) : float.NaN;
@@ -65,17 +64,15 @@ namespace QuestingBots.Components
         public bool IsCloseToObjective(float distance) => DistanceToObjective <= distance;
         public bool IsCloseToObjective() => IsCloseToObjective(Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotSearchDistances.OjectiveReachedIdeal);
 
-        public void StartJobAssigment() => assignment.Start();
-        public void ReportIncompletePath() => assignment.HasCompletePath = false;
-        public void RetryPath() => assignment.HasCompletePath = true;
-
-        public double? TimeSinceJobAssigmentStarted() => assignment.TimeSinceStarted();
+        public void StartJobAssigment() => CurrentAssignment?.Start();
+        
+        public double? TimeSinceJobAssigmentStarted() => CurrentAssignment?.TimeSinceStarted();
 
         public override string ToString()
         {
-            if (assignment.QuestAssignment != null)
+            if (CurrentAssignment?.QuestAssignment != null)
             {
-                return assignment.ToString();
+                return CurrentAssignment.ToString();
             }
 
             return "Position " + (Position?.ToString() ?? "???");
@@ -158,7 +155,7 @@ namespace QuestingBots.Components
 
             if (QuestSelector.NewAssignmentReady)
             {
-                BotJobAssignment? botJobAssignment = QuestSelector.GetCurrentJobAssignment();
+                BotJobAssignment? botJobAssignment = botOwner.GetMostRecentJobAssignment();
                 if (botJobAssignment != null)
                 {
                     SetObjective(botJobAssignment);
@@ -171,7 +168,7 @@ namespace QuestingBots.Components
                 return;
             }
 
-            bool? hasWaitedLongEnough = assignment?.HasWaitedLongEnoughAfterEnding();
+            bool? hasWaitedLongEnough = CurrentAssignment?.HasWaitedLongEnoughAfterEnding();
             if (hasWaitedLongEnough != true)
             {
                 return;
@@ -195,12 +192,7 @@ namespace QuestingBots.Components
                 return;
             }
 
-            if ((botQuestBuilder == null) && !Singleton<GameWorld>.Instance.TryGetComponent(out botQuestBuilder))
-            {
-                return;
-            }
-
-            if (!botQuestBuilder.HaveQuestsBeenBuilt)
+            if (!Singleton<GameWorld>.Instance.TryGetComponent(out BotQuestBuilder botQuestBuilder) || !botQuestBuilder.HaveQuestsBeenBuilt)
             {
                 return;
             }
@@ -219,9 +211,14 @@ namespace QuestingBots.Components
             IsInitialQuestSelectionComplete = true;
         }
 
-        public BotJobAssignment CloneCurrentJobAssignment(BotOwner otherBotToDoAssignment)
+        public BotJobAssignment? CloneCurrentJobAssignment(BotOwner otherBotToDoAssignment)
         {
-            BotJobAssignment clonedAssignment = new BotJobAssignment(otherBotToDoAssignment, assignment);
+            if (CurrentAssignment == null)
+            {
+                return null;
+            }
+
+            BotJobAssignment clonedAssignment = new BotJobAssignment(otherBotToDoAssignment, CurrentAssignment);
             BotJobAssignmentController.Register(clonedAssignment);
 
             return clonedAssignment;
@@ -229,18 +226,18 @@ namespace QuestingBots.Components
 
         public void SetObjective(BotJobAssignment objective)
         {
-            if (objective == assignment)
+            if (objective == CurrentAssignment)
             {
                 return;
             }
 
-            lastAssignment = assignment;
-            assignment = objective;
+            lastAssignment = CurrentAssignment;
+            CurrentAssignment = objective;
             QuestSelector.AcceptNewAssignment();
 
-            if (assignment != null)
+            if (CurrentAssignment != null)
             {
-                Singleton<LoggingUtil>.Instance.LogInfo("Bot " + botOwner.GetText() + " is now doing " + assignment.ToString());
+                Singleton<LoggingUtil>.Instance.LogInfo("Bot " + botOwner.GetText() + " is now doing " + CurrentAssignment.ToString());
             }
             else
             {
@@ -276,12 +273,18 @@ namespace QuestingBots.Components
 
         public void CompleteObjective()
         {
-            assignment.Complete();
+            if (CurrentAssignment == null)
+            {
+                Singleton<LoggingUtil>.Instance.LogError("Cannot complete a null assignment for " + botOwner.GetText());
+                return;
+            }
+
+            CurrentAssignment.Complete();
 
             BotPath.ClearPath();
 
             float duration = (float)WaitTimeAfterCompleting!.Value + 5;
-            UpdateLootingBehavior(assignment.QuestObjectiveAssignment.LootAfterCompletingSetting, duration);
+            UpdateLootingBehavior(CurrentAssignment.QuestObjectiveAssignment.LootAfterCompletingSetting, duration);
 
             foreach (BotOwner follower in BotLogic.HiveMind.BotHiveMindMonitor.GetFollowers(botOwner))
             {
@@ -292,7 +295,7 @@ namespace QuestingBots.Components
                     continue;
                 }
 
-                followerObjectiveManager.UpdateLootingBehavior(assignment.QuestObjectiveAssignment.LootAfterCompletingSetting, duration);
+                followerObjectiveManager.UpdateLootingBehavior(CurrentAssignment.QuestObjectiveAssignment.LootAfterCompletingSetting, duration);
             }
 
             StuckCount = 0;
@@ -300,7 +303,13 @@ namespace QuestingBots.Components
 
         public void FailObjective()
         {
-            assignment.Fail();
+            if (CurrentAssignment == null)
+            {
+                Singleton<LoggingUtil>.Instance.LogError("Cannot fail a null assignment for " + botOwner.GetText());
+                return;
+            }
+
+            CurrentAssignment.Fail();
         }
 
         public bool TryChangeObjective()
@@ -310,26 +319,26 @@ namespace QuestingBots.Components
                 return false;
             }
 
-            double? timeSinceJobEnded = assignment?.TimeSinceEnded();
+            double? timeSinceJobEnded = CurrentAssignment?.TimeSinceEnded();
             if (timeSinceJobEnded.HasValue && (timeSinceJobEnded.Value < Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.MinTimeBetweenSwitchingObjectives))
             {
                 Singleton<LoggingUtil>.Instance.LogWarning("Could not change the job assignment for " + botOwner.GetText() + " because not enough time has elapsed since it was last updated");
                 return false;
             }
 
-            assignment?.Inactivate();
+            CurrentAssignment?.Inactivate();
 
             return QuestSelector.TryCreateNewJobAssignment();
         }
 
         public void UnlockDoor(EFT.Interactive.WorldInteractiveObject door)
         {
-            assignment.SetDoorToUnlock(door);
+            CurrentAssignment?.SetDoorToUnlock(door);
         }
 
         public void DoorIsUnlocked()
         {
-            assignment.DoorIsUnlocked();
+            CurrentAssignment?.DoorIsUnlocked();
         }
 
         public void StopQuesting()
@@ -338,9 +347,29 @@ namespace QuestingBots.Components
             Singleton<LoggingUtil>.Instance.LogInfo(botOwner.GetText() + " is no longer allowed to quest.");
         }
 
+        public void ReportIncompletePath()
+        {
+            if (CurrentAssignment == null)
+            {
+                return;
+            }
+
+            CurrentAssignment.HasCompletePath = false;
+        }
+
+        public void RetryPath()
+        {
+            if (CurrentAssignment == null)
+            {
+                return;
+            }
+
+            CurrentAssignment.HasCompletePath = true;
+        }
+
         public bool CanSprintToObjective()
         {
-            if (assignment?.QuestObjectiveAssignment != null)
+            if (CurrentAssignment?.QuestObjectiveAssignment != null)
             {
                 if (DistanceToObjective < QuestingBotsPluginConfig.MinSprintingDistance.Value)
                 {
@@ -348,13 +377,13 @@ namespace QuestingBots.Components
                     return false;
                 }
 
-                if (DistanceToObjective < assignment.QuestObjectiveAssignment.MaxRunDistance)
+                if (DistanceToObjective < CurrentAssignment.QuestObjectiveAssignment.MaxRunDistance)
                 {
                     //Singleton<LoggingUtil>.Instance.LogInfo("Bot " + botOwner.GetText() + " will stop running because it's too close to " + assignment.Position.ToString());
                     return false;
                 }
 
-                if (!assignment.QuestAssignment.CanRunBetweenObjectives && (assignment.QuestAssignment.ElapsedTimeWhenLastEndedForBot(botOwner) > 0))
+                if (!CurrentAssignment.QuestAssignment.CanRunBetweenObjectives && (CurrentAssignment.QuestAssignment.ElapsedTimeWhenLastEndedForBot(botOwner) > 0))
                 {
                     //Singleton<LoggingUtil>.Instance.LogInfo("Bot " + botOwner.GetText() + " can no longer run for quest " + targetQuest.Name);
                     return false;
@@ -413,10 +442,10 @@ namespace QuestingBots.Components
         {
             if (MustUnlockDoor)
             {
-                return assignment?.DoorToUnlock!;
+                return CurrentAssignment?.DoorToUnlock!;
             }
 
-            return assignment?.QuestObjectiveStepAssignment?.InteractiveObject!;
+            return CurrentAssignment?.QuestObjectiveStepAssignment?.InteractiveObject!;
         }
 
         public bool DoesBotWantToExtract()

--- a/Client/Components/BotObjectiveManager.cs
+++ b/Client/Components/BotObjectiveManager.cs
@@ -236,6 +236,7 @@ namespace QuestingBots.Components
 
             lastAssignment = assignment;
             assignment = objective;
+            QuestSelector.AcceptNewAssignment();
 
             if (assignment != null)
             {

--- a/Client/Components/BotQuestBuilder.cs
+++ b/Client/Components/BotQuestBuilder.cs
@@ -19,7 +19,6 @@ using QuestingBots.Models.Pathing;
 using QuestingBots.Models.Questing;
 using QuestingBots.Utils;
 using UnityEngine;
-using BotQuest = QuestingBots.Models.Questing.BotQuest;
 
 namespace QuestingBots.Components
 {

--- a/Client/Components/BotQuestBuilder.cs
+++ b/Client/Components/BotQuestBuilder.cs
@@ -77,7 +77,7 @@ namespace QuestingBots.Components
             }
 
             airdopChaserQuest.MaxRaidET = RaidHelpers.GetRaidElapsedSeconds() + Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.AirdropBotInterestTime;
-            BotJobAssignmentFactory.AddQuest(airdopChaserQuest);
+            BotJobAssignmentController.AddQuest(airdopChaserQuest);
 
             Vector3 airdropQuestPosition = airdopChaserQuest.ValidObjectives.First().GetFirstStepPosition() ?? Vector3.negativeInfinity;
             Singleton<LoggingUtil>.Instance.LogInfo($"Added quest for the most recent airdop at {airdropPosition} with its objective position at {airdropQuestPosition}");
@@ -96,7 +96,7 @@ namespace QuestingBots.Components
 
             try
             {
-                if (BotJobAssignmentFactory.QuestCount == 0)
+                if (BotJobAssignmentController.QuestCount == 0)
                 {
                     // Create quests based on the EFT quest templates loaded from the server. This may include custom quests added by mods. 
                     SptRawQuestClass[] allQuestTemplates = Singleton<ConfigUtil>.Instance.GetAllQuestTemplates();
@@ -120,7 +120,7 @@ namespace QuestingBots.Components
                             quest.UpdateJSONProperties(eftQuestOverrideSettings[questTemplate.Id], overrideBindingFlags);
                         }
 
-                        BotJobAssignmentFactory.AddQuest(quest);
+                        BotJobAssignmentController.AddQuest(quest);
                     }
                 }
 
@@ -145,7 +145,7 @@ namespace QuestingBots.Components
                 }
 
                 // Process each of the quests created by an EFT quest template
-                yield return BotJobAssignmentFactory.ProcessAllQuests(LoadQuest, activeQuestsForPlayer);
+                yield return BotJobAssignmentController.ProcessAllQuests(LoadQuest, activeQuestsForPlayer);
 
                 Singleton<LoggingUtil>.Instance.LogInfo("Searching for EFT quest locations...");
 
@@ -157,7 +157,7 @@ namespace QuestingBots.Components
                 // Create quest objectives for all matching quest items found in the map
                 //IEnumerable<LootItem> allLoot = FindObjectsOfType<LootItem>(); <-- this does not work for inactive quest items!
                 IEnumerable<LootItem> allItems = Singleton<GameWorld>.Instance.LootItems.Where(i => i.Item != null).Distinct(i => i.TemplateId);
-                yield return BotJobAssignmentFactory.ProcessAllQuests(QuestHelpers.LocateQuestItems, allItems);
+                yield return BotJobAssignmentController.ProcessAllQuests(QuestHelpers.LocateQuestItems, allItems);
 
                 Singleton<LoggingUtil>.Instance.LogInfo("Searching for EFT quest locations...done.");
 
@@ -167,7 +167,7 @@ namespace QuestingBots.Components
                 if (spawnPointQuest != null)
                 {
                     //Singleton<LoggingUtil>.Instance.LogInfo("Adding quest for going to random spawn points...");
-                    BotJobAssignmentFactory.AddQuest(spawnPointQuest);
+                    BotJobAssignmentController.AddQuest(spawnPointQuest);
                 }
                 else
                 {
@@ -189,7 +189,7 @@ namespace QuestingBots.Components
                 if (spawnRushQuest != null)
                 {
                     //Singleton<LoggingUtil>.Instance.LogInfo("Adding quest for rushing your spawn point...");
-                    BotJobAssignmentFactory.AddQuest(spawnRushQuest);
+                    BotJobAssignmentController.AddQuest(spawnRushQuest);
                 }
                 else
                 {
@@ -205,16 +205,16 @@ namespace QuestingBots.Components
                     if (bossHunterQuest != null)
                     {
                         Singleton<LoggingUtil>.Instance.LogInfo("Adding quest for hunting boss " + boss + "...");
-                        BotJobAssignmentFactory.AddQuest(bossHunterQuest);
+                        BotJobAssignmentController.AddQuest(bossHunterQuest);
                     }
                 }
 
                 LoadCustomQuests();
 
-                BotJobAssignmentFactory.RemoveBlacklistedQuestObjectives(Singleton<GameWorld>.Instance.GetComponent<LocationData>().CurrentLocation.Id);
+                BotJobAssignmentController.RemoveBlacklistedQuestObjectives(Singleton<GameWorld>.Instance.GetComponent<LocationData>().CurrentLocation.Id);
 
                 // Update all other settings for EFT quests
-                yield return BotJobAssignmentFactory.ProcessAllQuests(updateEFTQuestObjectives);
+                yield return BotJobAssignmentController.ProcessAllQuests(updateEFTQuestObjectives);
 
                 HaveQuestsBeenBuilt = true;
                 Singleton<LoggingUtil>.Instance.LogInfo("Finished loading quest data.");
@@ -272,7 +272,7 @@ namespace QuestingBots.Components
                     continue;
                 }
 
-                BotJobAssignmentFactory.AddQuest(quest);
+                BotJobAssignmentController.AddQuest(quest);
             }
 
             Singleton<LoggingUtil>.Instance.LogInfo("Loading custom quests...found " + customQuests.Count() + " custom quests.");
@@ -338,7 +338,7 @@ namespace QuestingBots.Components
             }
 
             // Find all quests that have objectives using this trigger
-            BotQuest[] matchingQuests = BotJobAssignmentFactory.FindQuestsWithZone(trigger.Id);
+            BotQuest[] matchingQuests = BotJobAssignmentController.FindQuestsWithZone(trigger.Id);
             if (matchingQuests.Length == 0)
             {
                 //Singleton<LoggingUtil>.Instance.LogInfo("No matching quests for trigger " + trigger.Id);
@@ -501,7 +501,7 @@ namespace QuestingBots.Components
                 }
 
                 // Find all nearby quest objectives that are not from EFT quests
-                BotQuestObjective[] nearbyObjectives = BotJobAssignmentFactory.GetQuestObjectivesNearPosition(objectivePosition.Value, nearbyObjectiveDistance, false)
+                BotQuestObjective[] nearbyObjectives = BotJobAssignmentController.GetQuestObjectivesNearPosition(objectivePosition.Value, nearbyObjectiveDistance, false)
                     .ToArray();
 
                 // Match the looting behavior of the nearby objectives

--- a/Client/Components/BotQuestBuilder.cs
+++ b/Client/Components/BotQuestBuilder.cs
@@ -19,7 +19,7 @@ using QuestingBots.Models.Pathing;
 using QuestingBots.Models.Questing;
 using QuestingBots.Utils;
 using UnityEngine;
-using Quest = QuestingBots.Models.Questing.Quest;
+using BotQuest = QuestingBots.Models.Questing.BotQuest;
 
 namespace QuestingBots.Components
 {
@@ -70,7 +70,7 @@ namespace QuestingBots.Components
             // Need to wait at least one frame for the NavMeshObstacle to take effect
             yield return null;
 
-            Models.Questing.Quest airdopChaserQuest = createGoToPositionQuest(airdropPosition, "Airdrop Chaser", Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.AirdropChaser);
+            Models.Questing.BotQuest airdopChaserQuest = createGoToPositionQuest(airdropPosition, "Airdrop Chaser", Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.AirdropChaser);
             if (airdopChaserQuest == null)
             {
                 Singleton<LoggingUtil>.Instance.LogError("Could not add quest for the most recent airdop");
@@ -106,11 +106,11 @@ namespace QuestingBots.Components
                     Singleton<LoggingUtil>.Instance.LogDebug("Found override settings for " + eftQuestOverrideSettings.Count + " EFT quest(s)");
 
                     // Need to be able to override private properties
-                    BindingFlags overrideBindingFlags = Models.JSONObject<Models.Questing.Quest>.DefaultPropertySearchBindingFlags | System.Reflection.BindingFlags.NonPublic;
+                    BindingFlags overrideBindingFlags = Models.JSONObject<Models.Questing.BotQuest>.DefaultPropertySearchBindingFlags | System.Reflection.BindingFlags.NonPublic;
 
                     foreach (SptRawQuestClass questTemplate in allQuestTemplates)
                     {
-                        Quest quest = new Quest(questTemplate);
+                        BotQuest quest = new BotQuest(questTemplate);
 
                         quest.ApplyQuestSettingsFromConfig(Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.EFTQuests);
                         quest.PMCsOnly = true;
@@ -164,7 +164,7 @@ namespace QuestingBots.Components
 
                 // Create a quest where the bots wanders to various spawn points around the map. This was implemented as a stop-gap for maps with few other quests.
                 SpawnPointParams[] allSpawnPoints = Singleton<GameWorld>.Instance.GetComponent<LocationData>().CurrentLocation.SpawnPointParams;
-                Quest spawnPointQuest = createSpawnPointQuest(allSpawnPoints, "Spawn Point Wander", Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.SpawnPointWander);
+                BotQuest spawnPointQuest = createSpawnPointQuest(allSpawnPoints, "Spawn Point Wander", Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.SpawnPointWander);
                 if (spawnPointQuest != null)
                 {
                     //Singleton<LoggingUtil>.Instance.LogInfo("Adding quest for going to random spawn points...");
@@ -176,7 +176,7 @@ namespace QuestingBots.Components
                 }
 
                 // Create a quest where initial PMC's can run to your spawn point (not directly to you).
-                Models.Questing.Quest spawnRushQuest = null!;
+                Models.Questing.BotQuest spawnRushQuest = null!;
                 SpawnPointParams? playerSpawnPoint = Singleton<GameWorld>.Instance.GetComponent<LocationData>().GetMainPlayerSpawnPoint();
                 if (playerSpawnPoint.HasValue)
                 {
@@ -202,7 +202,7 @@ namespace QuestingBots.Components
                 foreach (string boss in bossSpawnZones.Keys)
                 {
                     IEnumerable<SpawnPointParams> possibleBossSpawnPoints = allSpawnPoints.Where(s => bossSpawnZones[boss].Contains(s.BotZoneName ?? ""));
-                    Quest bossHunterQuest = createSpawnPointQuest(possibleBossSpawnPoints, "Boss Hunter (" + boss + ")", Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.BossHunter);
+                    BotQuest bossHunterQuest = createSpawnPointQuest(possibleBossSpawnPoints, "Boss Hunter (" + boss + ")", Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.BossHunter);
                     if (bossHunterQuest != null)
                     {
                         Singleton<LoggingUtil>.Instance.LogInfo("Adding quest for hunting boss " + boss + "...");
@@ -231,17 +231,17 @@ namespace QuestingBots.Components
         private void LoadCustomQuests()
         {
             // Load all JSON files for custom quests
-            IEnumerable<Quest> customQuests = Singleton<ConfigUtil>.Instance.GetCustomQuests(Singleton<GameWorld>.Instance.GetComponent<LocationData>().CurrentLocation.Id);
+            IEnumerable<BotQuest> customQuests = Singleton<ConfigUtil>.Instance.GetCustomQuests(Singleton<GameWorld>.Instance.GetComponent<LocationData>().CurrentLocation.Id);
             if (!customQuests.Any())
             {
                 return;
             }
 
             Singleton<LoggingUtil>.Instance.LogInfo("Loading custom quests...");
-            foreach (Quest quest in customQuests)
+            foreach (BotQuest quest in customQuests)
             {
                 int objectiveNum = 0;
-                foreach (QuestObjective objective in quest.ValidObjectives.ToArray())
+                foreach (BotQuestObjective objective in quest.ValidObjectives.ToArray())
                 {
                     objectiveNum++;
                     objective.SetName(quest.GetName() + ": Objective #" + objectiveNum);
@@ -279,7 +279,7 @@ namespace QuestingBots.Components
             Singleton<LoggingUtil>.Instance.LogInfo("Loading custom quests...found " + customQuests.Count() + " custom quests.");
         }
 
-        private void LoadQuest(Models.Questing.Quest quest, IEnumerable<QuestDataClass> activeQuestsForPlayer)
+        private void LoadQuest(Models.Questing.BotQuest quest, IEnumerable<QuestDataClass> activeQuestsForPlayer)
         {
             quest.MaxBots = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.EFTQuests.MaxBotsPerQuest;
 
@@ -297,7 +297,7 @@ namespace QuestingBots.Components
                 }
 
                 // Add a new objective for the zone
-                QuestZoneObjective objective = new QuestZoneObjective(zoneID);
+                BotQuestZoneObjective objective = new BotQuestZoneObjective(zoneID);
                 quest.AddObjective(objective);
             }
 
@@ -339,7 +339,7 @@ namespace QuestingBots.Components
             }
 
             // Find all quests that have objectives using this trigger
-            Quest[] matchingQuests = BotJobAssignmentFactory.FindQuestsWithZone(trigger.Id);
+            BotQuest[] matchingQuests = BotJobAssignmentFactory.FindQuestsWithZone(trigger.Id);
             if (matchingQuests.Length == 0)
             {
                 //Singleton<LoggingUtil>.Instance.LogInfo("No matching quests for trigger " + trigger.Id);
@@ -355,12 +355,12 @@ namespace QuestingBots.Components
             }
 
             // Add a step with the NavMesh position to corresponding objectives in every quest using this zone
-            foreach (Quest quest in matchingQuests)
+            foreach (BotQuest quest in matchingQuests)
             {
                 Singleton<LoggingUtil>.Instance.LogDebug("Found trigger " + trigger.Id + " for quest: " + quest.GetName());
 
-                QuestObjective objective = quest.GetObjectiveForZoneID(trigger.Id);
-                objective.AddStep(new QuestObjectiveStep(navMeshTargetPoint.Value));
+                BotQuestObjective objective = quest.GetObjectiveForZoneID(trigger.Id);
+                objective.AddStep(new BotQuestObjectiveStep(navMeshTargetPoint.Value));
 
                 float? plantTime = quest.FindPlantTime(trigger.Id);
                 if (plantTime.HasValue)
@@ -368,7 +368,7 @@ namespace QuestingBots.Components
                     Singleton<LoggingUtil>.Instance.LogDebug("Found trigger " + trigger.Id + " for quest: " + quest.GetName() + " - Adding plant time: " + plantTime.Value + "s");
 
                     Configuration.MinMaxConfig plantTimeMinMax = new Configuration.MinMaxConfig(plantTime.Value, plantTime.Value);
-                    objective.AddStep(new QuestObjectiveStep(navMeshTargetPoint.Value, QuestAction.PlantItem, plantTimeMinMax));
+                    objective.AddStep(new BotQuestObjectiveStep(navMeshTargetPoint.Value, QuestAction.PlantItem, plantTimeMinMax));
                     objective.LootAfterCompletingSetting = LootAfterCompleting.Inhibit;
                 }
 
@@ -475,7 +475,7 @@ namespace QuestingBots.Components
             return cost;
         }
 
-        private void updateEFTQuestObjectives(Models.Questing.Quest quest)
+        private void updateEFTQuestObjectives(Models.Questing.BotQuest quest)
         {
             if (!quest.IsEFTQuest)
             {
@@ -483,9 +483,9 @@ namespace QuestingBots.Components
             }
 
             float nearbyObjectiveDistance = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.EFTQuests.MatchLootingBehaviorDistance;
-            foreach (QuestObjective objective in quest.AllObjectives)
+            foreach (BotQuestObjective objective in quest.AllObjectives)
             {
-                foreach (QuestObjectiveStep step in objective.AllSteps)
+                foreach (BotQuestObjectiveStep step in objective.AllSteps)
                 {
                     step.ChanceOfHavingKey = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.EFTQuests.ChanceOfHavingKeys;
                 }
@@ -502,7 +502,7 @@ namespace QuestingBots.Components
                 }
 
                 // Find all nearby quest objectives that are not from EFT quests
-                QuestObjective[] nearbyObjectives = BotJobAssignmentFactory.GetQuestObjectivesNearPosition(objectivePosition.Value, nearbyObjectiveDistance, false)
+                BotQuestObjective[] nearbyObjectives = BotJobAssignmentFactory.GetQuestObjectivesNearPosition(objectivePosition.Value, nearbyObjectiveDistance, false)
                     .ToArray();
 
                 // Match the looting behavior of the nearby objectives
@@ -514,7 +514,7 @@ namespace QuestingBots.Components
             }
         }
 
-        private Models.Questing.Quest createGoToPositionQuest(Vector3 position, string questName, QuestSettingsConfig settings)
+        private Models.Questing.BotQuest createGoToPositionQuest(Vector3 position, string questName, QuestSettingsConfig settings)
         {
             if (position == null)
             {
@@ -539,10 +539,10 @@ namespace QuestingBots.Components
                 return null!;
             }
 
-            Models.Questing.Quest quest = new Models.Questing.Quest(questName);
+            Models.Questing.BotQuest quest = new Models.Questing.BotQuest(questName);
             quest.ApplyQuestSettingsFromConfig(settings);
 
-            Models.Questing.QuestObjective objective = new Models.Questing.QuestObjective(navMeshPosition.Value);
+            Models.Questing.BotQuestObjective objective = new Models.Questing.BotQuestObjective(navMeshPosition.Value);
             objective.ApplyQuestSettingsFromConfig(settings);
             objective.SetName(quest.GetName() + ": Objective #1");
             quest.AddObjective(objective);
@@ -550,7 +550,7 @@ namespace QuestingBots.Components
             return quest;
         }
 
-        private Models.Questing.Quest createSpawnPointQuest(IEnumerable<SpawnPointParams> spawnPoints, string questName, QuestSettingsConfig settings, ESpawnCategoryMask spawnTypes = ESpawnCategoryMask.All)
+        private Models.Questing.BotQuest createSpawnPointQuest(IEnumerable<SpawnPointParams> spawnPoints, string questName, QuestSettingsConfig settings, ESpawnCategoryMask spawnTypes = ESpawnCategoryMask.All)
         {
             if (spawnPoints == null)
             {
@@ -574,7 +574,7 @@ namespace QuestingBots.Components
                 return null!;
             }
 
-            Models.Questing.Quest quest = new Models.Questing.Quest(questName);
+            Models.Questing.BotQuest quest = new Models.Questing.BotQuest(questName);
             quest.ApplyQuestSettingsFromConfig(settings);
 
             int objNum = 1;
@@ -588,7 +588,7 @@ namespace QuestingBots.Components
                     continue;
                 }
 
-                Models.Questing.QuestSpawnPointObjective objective = new Models.Questing.QuestSpawnPointObjective(spawnPoint, spawnPoint.Position);
+                Models.Questing.BotQuestSpawnPointObjective objective = new Models.Questing.BotQuestSpawnPointObjective(spawnPoint, spawnPoint.Position);
                 objective.ApplyQuestSettingsFromConfig(settings);
                 objective.SetName(quest.GetName() + ": Objective #" + objNum);
                 quest.AddObjective(objective);

--- a/Client/Components/BotQuestBuilder.cs
+++ b/Client/Components/BotQuestBuilder.cs
@@ -79,7 +79,7 @@ namespace QuestingBots.Components
             airdopChaserQuest.MaxRaidET = RaidHelpers.GetRaidElapsedSeconds() + Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.AirdropBotInterestTime;
             BotJobAssignmentController.AddQuest(airdopChaserQuest);
 
-            Vector3 airdropQuestPosition = airdopChaserQuest.ValidObjectives.First().GetFirstStepPosition() ?? Vector3.negativeInfinity;
+            Vector3 airdropQuestPosition = airdopChaserQuest.GetValidObjectives().First().GetFirstStepPosition() ?? Vector3.negativeInfinity;
             Singleton<LoggingUtil>.Instance.LogInfo($"Added quest for the most recent airdop at {airdropPosition} with its objective position at {airdropQuestPosition}");
 
             if (airdropBounds.Contains(airdropQuestPosition))
@@ -240,7 +240,7 @@ namespace QuestingBots.Components
             foreach (BotQuest quest in customQuests)
             {
                 int objectiveNum = 0;
-                foreach (BotQuestObjective objective in quest.ValidObjectives.ToArray())
+                foreach (BotQuestObjective objective in quest.GetValidObjectives())
                 {
                     objectiveNum++;
                     objective.SetName(quest.GetName() + ": Objective #" + objectiveNum);
@@ -266,7 +266,7 @@ namespace QuestingBots.Components
                 }
 
                 // Do not use quests that don't have any valid objectives (using the check above)
-                if (!quest.ValidObjectives.Any() || quest.ValidObjectives.All(o => o.StepCount == 0))
+                if (!quest.GetValidObjectives().Any() || quest.GetValidObjectives().All(o => o.StepCount == 0))
                 {
                     Singleton<LoggingUtil>.Instance.LogError("Could not find any valid objectives for quest " + quest.GetName() + ". Disabling quest.");
                     continue;

--- a/Client/Components/BotQuestSelector.cs
+++ b/Client/Components/BotQuestSelector.cs
@@ -1,0 +1,375 @@
+﻿using Comfort.Common;
+using EFT;
+using EFT.Interactive;
+using QuestingBots.BotLogic.BotMonitor.Monitors;
+using QuestingBots.Controllers;
+using QuestingBots.Helpers;
+using QuestingBots.Models.Questing;
+using QuestingBots.Utils;
+using QuestingBots.Utils.Benchmarking;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace QuestingBots.Components
+{
+    public class BotQuestSelector : BehaviorExtensions.MonoBehaviourDelayedUpdate
+    {
+        private BotOwner _botOwner = null!;
+        private ExfiltrationPoint exfiltrationPoint = null!;
+
+        public static BotQuestSelector GetBotQuestSelector(BotOwner botOwner)
+        {
+            BotQuestSelector botQuestSelector = botOwner.gameObject.GetOrAddComponent<BotQuestSelector>();
+            botQuestSelector.Init(botOwner);
+
+            return botQuestSelector;
+        }
+
+        public void Init(BotOwner botOwner)
+        {
+            _botOwner = botOwner;
+            SetExfiliationPointForQuesting();
+        }
+
+        [Benchmark]
+        public BotJobAssignment? GetInitialObjective()
+        {
+            BotObjectiveManager? objectiveManager = _botOwner.GetObjectiveManager();
+            if (objectiveManager == null)
+            {
+                Singleton<LoggingUtil>.Instance.LogError("Cannot retrieve BotObjectiveManager for " + _botOwner.GetText());
+                return null;
+            }
+
+            // Only set an objective for the bot if its type is allowed to spawn and all quests have been loaded and generated
+            if (!objectiveManager.IsQuestingAllowed || !Singleton<GameWorld>.Instance.GetComponent<Components.BotQuestBuilder>().HaveQuestsBeenBuilt)
+            {
+                return null;
+            }
+
+            Singleton<LoggingUtil>.Instance.LogInfo("Setting objective for " + _botOwner.GetText() + " (Brain type: " + _botOwner.Brain.BaseBrain.ShortName() + ")...");
+            try
+            {
+                BotJobAssignment? botJobAssignment = GetCurrentJobAssignment();
+                return botJobAssignment;
+            }
+            catch (TimeoutException)
+            {
+                Singleton<LoggingUtil>.Instance.LogError("Timed out when trying to select an initial objective for " + _botOwner.GetText());
+            }
+
+            return null;
+        }
+
+        [Benchmark]
+        public void SetExfiliationPointForQuesting()
+        {
+            Dictionary<ExfiltrationPoint, float> exfiltrationPointDistances = Singleton<GameWorld>.Instance.ExfiltrationController.ExfiltrationPoints
+                .ToDictionary(p => p, p => Vector3.Distance(p.transform.position, _botOwner.Position));
+
+            if (exfiltrationPointDistances.Count > 0)
+            {
+                KeyValuePair<ExfiltrationPoint, float> furthestPoint = exfiltrationPointDistances
+                    .OrderBy(p => p.Value)
+                    .Last();
+
+                exfiltrationPoint = furthestPoint.Key;
+
+                //Singleton<LoggingUtil>.Instance.LogInfo(botOwner.GetText() + " has selected " + furthestPoint.Key.Settings.Name + " as its furthest exfil point (" + furthestPoint.Value + "m)");
+            }
+        }
+
+        public float? DistanceToExfiltrationPointForQuesting()
+        {
+            if (exfiltrationPoint == null)
+            {
+                return null;
+            }
+
+            return Vector3.Distance(_botOwner.Position, exfiltrationPoint.transform.position);
+        }
+
+        public Vector3? VectorToExfiltrationPointForQuesting()
+        {
+            if (exfiltrationPoint == null)
+            {
+                return null;
+            }
+
+            return exfiltrationPoint.transform.position - _botOwner.Position;
+        }
+
+        public BotJobAssignment? GetCurrentJobAssignment(bool allowUpdate = true)
+        {
+            bool hasNewJobAssignment = allowUpdate && DoesBotHaveNewJobAssignment();
+            BotJobAssignment? mostRecentAssignment = _botOwner.GetMostRecentJobAssignment();
+
+            if (hasNewJobAssignment && (mostRecentAssignment != null))
+            {
+                Singleton<LoggingUtil>.Instance.LogInfo("Bot " + _botOwner.GetText() + " is now doing " + mostRecentAssignment.ToString());
+
+                ReadOnlyCollection<BotJobAssignment> allJobAssignments = _botOwner.GetAllBotJobAssignments();
+
+                if (allJobAssignments.Count > 1)
+                {
+                    BotJobAssignment lastAssignment = allJobAssignments.TakeLast(2).First();
+                    Singleton<LoggingUtil>.Instance.LogDebug("Bot " + _botOwner.GetText() + " was previously doing " + lastAssignment.ToString());
+
+                    //double? timeSinceBotStartedQuest = lastAssignment.QuestAssignment.ElapsedTimeSinceBotStarted(bot);
+                    //double? timeSinceBotLastFinishedQuest = lastAssignment.QuestAssignment.ElapsedTimeWhenLastEndedForBot(bot);
+                    //string startedTimeText = timeSinceBotStartedQuest.HasValue ? timeSinceBotStartedQuest.Value.ToString() : "N/A";
+                    //string lastFinishedTimeText = timeSinceBotLastFinishedQuest.HasValue ? timeSinceBotLastFinishedQuest.Value.ToString() : "N/A";
+                    //Singleton<LoggingUtil>.Instance.LogInfo("Time since first objective ended: " + startedTimeText + ", Time since last objective ended: " + lastFinishedTimeText);
+                }
+            }
+
+            if (allowUpdate && (mostRecentAssignment == null))
+            {
+                Singleton<LoggingUtil>.Instance.LogWarning("Could not get a job assignment for bot " + _botOwner.GetText());
+            }
+
+            return mostRecentAssignment;
+        }
+
+        public bool DoesBotHaveNewJobAssignment()
+        {
+            BotJobAssignment? mostRecentAssignment = _botOwner.GetMostRecentJobAssignment();
+            if (mostRecentAssignment != null)
+            {
+                // Check if the bot is currently doing an assignment
+                if (mostRecentAssignment.IsActive)
+                {
+                    return false;
+                }
+
+                // Check if more steps are available for the bot's current assignment
+                if (mostRecentAssignment.TrySetNextObjectiveStep(false))
+                {
+                    return true;
+                }
+
+                //Singleton<LoggingUtil>.Instance.LogInfo("There are no more steps available for " + bot.GetText() + " in " + (currentAssignment.QuestObjectiveAssignment?.ToString() ?? "???"));
+            }
+
+            BotJobAssignment? newJobAssignment = GetNewBotJobAssignment();
+            if (newJobAssignment != null)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        [Benchmark]
+        public BotJobAssignment? GetNewBotJobAssignment()
+        {
+            if (_botOwner == null)
+            {
+                throw new ArgumentNullException("Cannot get an assignment for a null bot");
+            }
+
+            BotObjectiveManager? objectiveManager = _botOwner.GetObjectiveManager();
+            if (objectiveManager == null)
+            {
+                Singleton<LoggingUtil>.Instance.LogError("Cannot retrieve BotObjectiveManager for " + _botOwner.GetText());
+                return null;
+            }
+
+            // Do not select another quest objective if the bot wants to extract
+            if (objectiveManager.DoesBotWantToExtract())
+            {
+                return null;
+            }
+
+            float maxDistanceBetweenExfils = Singleton<GameWorld>.Instance.GetComponent<Components.LocationData>().GetMaxDistanceBetweenExfils();
+            float minDistanceToSwitchExfil = maxDistanceBetweenExfils * Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilReachedMinFraction;
+
+            // If the bot is close to its selected exfil (only used for quest selection), select a new one
+            float? distanceToExfilPoint = objectiveManager.QuestSelector.DistanceToExfiltrationPointForQuesting();
+            if (distanceToExfilPoint.HasValue && (distanceToExfilPoint.Value < minDistanceToSwitchExfil))
+            {
+                objectiveManager.QuestSelector.SetExfiliationPointForQuesting();
+            }
+
+            // Get the bot's most recent assingment if applicable
+            BotJobAssignment? mostRecentAssignment = _botOwner.GetMostRecentJobAssignment();
+            BotQuest? quest = mostRecentAssignment?.QuestAssignment;
+            BotQuestObjective? objective = mostRecentAssignment?.QuestObjectiveAssignment;
+
+            // Clear the bot's assignment if it's been doing the same quest for too long
+            if ((quest?.HasBotBeingDoingQuestTooLong(_botOwner, out double? timeDoingQuest) == true) && (timeDoingQuest != null))
+            {
+                Singleton<LoggingUtil>.Instance.LogInfo(_botOwner.GetText() + " has been performing quest " + quest.ToString() + " for " + timeDoingQuest.Value + "s and will get a new one.");
+                quest = null;
+                objective = null;
+            }
+
+            // Try to find a quest that has at least one objective that can be assigned to the bot
+            List<BotQuest> invalidQuests = new List<BotQuest>();
+            Stopwatch timeoutMonitor = Stopwatch.StartNew();
+            do
+            {
+                // Find the nearest objective for the bot's currently assigned quest (if any)
+                objective = quest?
+                    .RemainingObjectivesForBot(_botOwner)?
+                    .Where(o => o.CanAssignBot(_botOwner))?
+                    .Where(o => o.CanBotRepeatQuestObjective(_botOwner))?
+                    .NearestToBot(_botOwner);
+
+                // Exit the loop if an objective was found for the bot
+                if (objective != null)
+                {
+                    break;
+                }
+                if (quest != null)
+                {
+                    //Singleton<LoggingUtil>.Instance.LogInfo(bot.GetText() + " cannot select quest " + quest.ToString() + " because it has no valid objectives");
+                    invalidQuests.Add(quest);
+                }
+
+                // If no objectives were found, select another quest
+                quest = GetRandomQuest(invalidQuests);
+
+                // If a quest hasn't been found within a certain amount of time, something is wrong
+                if (timeoutMonitor.ElapsedMilliseconds > Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.QuestSelectionTimeout)
+                {
+                    // First try allowing the bot to repeat quests it already completed
+                    if (_botOwner.TryArchiveRepeatableAssignments() > 0)
+                    {
+                        Singleton<LoggingUtil>.Instance.LogWarning(_botOwner.GetText() + " cannot select any quests. Trying to select a repeatable quest early instead...");
+                        continue;
+                    }
+
+                    // If there are still no quests available for the bot to select, give up trying to select one
+                    Singleton<LoggingUtil>.Instance.LogError(_botOwner.GetText() + " could not select any of the following quests: " + string.Join(", ", _botOwner.GetAllPossibleQuests()));
+                    objectiveManager.StopQuesting();
+
+                    // Try making the bot extract because it has nothing to do
+                    if (objectiveManager.BotMonitor.GetMonitor<BotExtractMonitor>().TryInstructBotToExtract())
+                    {
+                        Singleton<LoggingUtil>.Instance.LogWarning(_botOwner.GetText() + " cannot select any quests. Extracting instead...");
+                        return null;
+                    }
+
+                    Singleton<LoggingUtil>.Instance.LogError(_botOwner.GetText() + " cannot select any quests. Questing disabled.");
+                    return null;
+                }
+
+            } while (objective == null);
+
+            if (quest == null)
+            {
+                return null;
+            }
+
+            // Once a valid assignment is selected, assign it to the bot
+            BotJobAssignment assignment = new BotJobAssignment(_botOwner, quest, objective);
+            assignment.Register();
+
+            return assignment;
+        }
+
+        public BotQuest GetRandomQuest(IEnumerable<BotQuest> invalidQuests)
+        {
+            if (_botOwner == null)
+            {
+                throw new ArgumentNullException("Cannot get a quest for a null bot");
+            }
+
+            Stopwatch questSelectionTimer = Stopwatch.StartNew();
+
+            BotQuest[] assignableQuests = _botOwner.GetAllPossibleQuests()
+                .Where(q => !invalidQuests.Contains(q))
+                .ToArray();
+
+            if (!assignableQuests.Any())
+            {
+                return null!;
+            }
+
+            Vector3? vectorToExfil = VectorToExfiltrationPointForQuesting();
+
+            Dictionary<BotQuest, Configuration.MinMaxConfig> questDistanceRanges = new Dictionary<BotQuest, Configuration.MinMaxConfig>();
+            Dictionary<BotQuest, Configuration.MinMaxConfig> questExfilAngleRanges = new Dictionary<BotQuest, Configuration.MinMaxConfig>();
+
+            // Calculate the distances from the bot to all valid quest objectives and the angles between the vector to the bot's selected
+            // exfil (for questing) and the vector to each valid quest objective
+            foreach (BotQuest quest in assignableQuests)
+            {
+                IEnumerable<Vector3?> objectivePositions = quest.ValidObjectives.Select(o => o.GetFirstStepPosition());
+                IEnumerable<Vector3> validObjectivePositions = objectivePositions.Where(p => p.HasValue).Select(p => p!.Value);
+                IEnumerable<float> distancesToObjectives = validObjectivePositions.Select(p => Vector3.Distance(_botOwner.Position, p));
+
+                questDistanceRanges.Add(quest, new Configuration.MinMaxConfig(distancesToObjectives.Min(), distancesToObjectives.Max()));
+
+                if (vectorToExfil.HasValue)
+                {
+                    IEnumerable<Vector3> vectorsToObjectivePositions = validObjectivePositions.Select(p => p - _botOwner.Position);
+                    IEnumerable<float> anglesToObjectives = vectorsToObjectivePositions.Select(p => Vector3.Angle(p - _botOwner.Position, vectorToExfil.Value));
+
+                    questExfilAngleRanges.Add(quest, new Configuration.MinMaxConfig(anglesToObjectives.Min(), anglesToObjectives.Max()));
+                }
+                else
+                {
+                    questExfilAngleRanges.Add(quest, new Configuration.MinMaxConfig(0, 0));
+                }
+            }
+
+            // Calculate the maximum amount of "randomness" to apply to each quest
+            //double distanceRange = questDistanceRanges.Max(q => q.Value.Max) - questDistanceRanges.Min(q => q.Value.Min);
+            double maxDistance = questDistanceRanges.Max(o => o.Value.Max);
+            int maxRandomDistance = (int)Math.Ceiling(maxDistance * Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DistanceRandomness / 100.0);
+            float maxExfilAngle = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionMaxAngle;
+
+            int distanceRandomness = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DistanceRandomness;
+            int desirabilityRandomness = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DesirabilityRandomness;
+
+            float distanceWeighting = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DistanceWeighting;
+            float desirabilityWeighting = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DesirabilityWeighting;
+            float exfilDirectionWeighting = 0;
+
+            string locationId = Singleton<GameWorld>.Instance.GetComponent<Components.LocationData>().CurrentLocation.Id;
+            if (Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionWeighting.ContainsKey(locationId))
+            {
+                exfilDirectionWeighting = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionWeighting[locationId];
+            }
+            else if (Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionWeighting.ContainsKey("default"))
+            {
+                exfilDirectionWeighting = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionWeighting["default"];
+            }
+
+            System.Random random = new System.Random();
+            Dictionary<BotQuest, double> questDistanceFractions = questDistanceRanges
+                .ToDictionary(o => o.Key, o => 1 - (o.Value.Min + random.Next(-1 * maxRandomDistance, maxRandomDistance)) / maxDistance);
+            Dictionary<BotQuest, float> questDesirabilityFractions = questDistanceRanges
+                .ToDictionary(o => o.Key, o =>
+                (
+                    o.Key.Desirability * (o.Key.IsActiveForPlayer ? Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DesirabilityActiveQuestMultiplier : 1)
+                    + random.Next(-1 * desirabilityRandomness, desirabilityRandomness)) / 100
+                );
+            Dictionary<BotQuest, double> questExfilAngleFactor = questExfilAngleRanges
+                .ToDictionary(o => o.Key, o => Math.Max(0, o.Value.Min - maxExfilAngle) / (180 - maxExfilAngle));
+
+            IEnumerable<BotQuest> sortedQuests = questDistanceRanges
+                .OrderBy
+                (o =>
+                    (questDistanceFractions[o.Key] * distanceWeighting)
+                    + (questDesirabilityFractions[o.Key] * desirabilityWeighting)
+                    - (questExfilAngleFactor[o.Key] * exfilDirectionWeighting)
+                )
+                .Select(o => o.Key);
+
+            BotQuest selectedQuest = sortedQuests.Last();
+
+            //Singleton<LoggingUtil>.Instance.LogInfo("Distance: " + questDistanceFractions[selectedQuest] + ", Desirability: " + questDesirabilityFractions[selectedQuest] + ", Exfil Angle Factor: " + questExfilAngleFactor[selectedQuest]);
+            //Singleton<LoggingUtil>.Instance.LogInfo("Time for quest selection: " + questSelectionTimer.ElapsedMilliseconds + "ms");
+
+            return selectedQuest;
+        }
+    }
+}

--- a/Client/Components/BotQuestSelector.cs
+++ b/Client/Components/BotQuestSelector.cs
@@ -1,13 +1,13 @@
 ﻿using Comfort.Common;
 using EFT;
 using EFT.Interactive;
-using QuestingBots.BotLogic.BotMonitor.Monitors;
 using QuestingBots.Controllers;
 using QuestingBots.Helpers;
 using QuestingBots.Models.Questing;
 using QuestingBots.Utils;
 using QuestingBots.Utils.Benchmarking;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
@@ -21,6 +21,9 @@ namespace QuestingBots.Components
     {
         private BotOwner _botOwner = null!;
         private ExfiltrationPoint exfiltrationPoint = null!;
+        private BotJobAssignmentCreationJob? assignmentCreationJob = null;
+
+        public bool NewAssignmentReady => assignmentCreationJob?.NewAssignmentReady == true;
 
         public static BotQuestSelector GetBotQuestSelector(BotOwner botOwner)
         {
@@ -34,36 +37,6 @@ namespace QuestingBots.Components
         {
             _botOwner = botOwner;
             SetExfiliationPointForQuesting();
-        }
-
-        [Benchmark]
-        public BotJobAssignment? GetInitialObjective()
-        {
-            BotObjectiveManager? objectiveManager = _botOwner.GetObjectiveManager();
-            if (objectiveManager == null)
-            {
-                Singleton<LoggingUtil>.Instance.LogError("Cannot retrieve BotObjectiveManager for " + _botOwner.GetText());
-                return null;
-            }
-
-            // Only set an objective for the bot if its type is allowed to spawn and all quests have been loaded and generated
-            if (!objectiveManager.IsQuestingAllowed || !Singleton<GameWorld>.Instance.GetComponent<Components.BotQuestBuilder>().HaveQuestsBeenBuilt)
-            {
-                return null;
-            }
-
-            Singleton<LoggingUtil>.Instance.LogInfo("Setting objective for " + _botOwner.GetText() + " (Brain type: " + _botOwner.Brain.BaseBrain.ShortName() + ")...");
-            try
-            {
-                BotJobAssignment? botJobAssignment = GetCurrentJobAssignment();
-                return botJobAssignment;
-            }
-            catch (TimeoutException)
-            {
-                Singleton<LoggingUtil>.Instance.LogError("Timed out when trying to select an initial objective for " + _botOwner.GetText());
-            }
-
-            return null;
         }
 
         [Benchmark]
@@ -84,53 +57,19 @@ namespace QuestingBots.Components
             }
         }
 
-        public float? DistanceToExfiltrationPointForQuesting()
-        {
-            if (exfiltrationPoint == null)
-            {
-                return null;
-            }
-
-            return Vector3.Distance(_botOwner.Position, exfiltrationPoint.transform.position);
-        }
-
-        public Vector3? VectorToExfiltrationPointForQuesting()
-        {
-            if (exfiltrationPoint == null)
-            {
-                return null;
-            }
-
-            return exfiltrationPoint.transform.position - _botOwner.Position;
-        }
-
         public BotJobAssignment? GetCurrentJobAssignment(bool allowUpdate = true)
         {
             bool hasNewJobAssignment = allowUpdate && DoesBotHaveNewJobAssignment();
+
             BotJobAssignment? mostRecentAssignment = _botOwner.GetMostRecentJobAssignment();
-
-            if (hasNewJobAssignment && (mostRecentAssignment != null))
+            if (!hasNewJobAssignment)
             {
-                Singleton<LoggingUtil>.Instance.LogInfo("Bot " + _botOwner.GetText() + " is now doing " + mostRecentAssignment.ToString());
-
-                ReadOnlyCollection<BotJobAssignment> allJobAssignments = _botOwner.GetAllBotJobAssignments();
-
-                if (allJobAssignments.Count > 1)
-                {
-                    BotJobAssignment lastAssignment = allJobAssignments.TakeLast(2).First();
-                    Singleton<LoggingUtil>.Instance.LogDebug("Bot " + _botOwner.GetText() + " was previously doing " + lastAssignment.ToString());
-
-                    //double? timeSinceBotStartedQuest = lastAssignment.QuestAssignment.ElapsedTimeSinceBotStarted(bot);
-                    //double? timeSinceBotLastFinishedQuest = lastAssignment.QuestAssignment.ElapsedTimeWhenLastEndedForBot(bot);
-                    //string startedTimeText = timeSinceBotStartedQuest.HasValue ? timeSinceBotStartedQuest.Value.ToString() : "N/A";
-                    //string lastFinishedTimeText = timeSinceBotLastFinishedQuest.HasValue ? timeSinceBotLastFinishedQuest.Value.ToString() : "N/A";
-                    //Singleton<LoggingUtil>.Instance.LogInfo("Time since first objective ended: " + startedTimeText + ", Time since last objective ended: " + lastFinishedTimeText);
-                }
+                return mostRecentAssignment;
             }
-
-            if (allowUpdate && (mostRecentAssignment == null))
+            
+            if (assignmentCreationJob != null)
             {
-                Singleton<LoggingUtil>.Instance.LogWarning("Could not get a job assignment for bot " + _botOwner.GetText());
+                return assignmentCreationJob.AssignmentCreationResult;
             }
 
             return mostRecentAssignment;
@@ -150,226 +89,71 @@ namespace QuestingBots.Components
                 // Check if more steps are available for the bot's current assignment
                 if (mostRecentAssignment.TrySetNextObjectiveStep(false))
                 {
+                    assignmentCreationJob = null;
                     return true;
                 }
 
                 //Singleton<LoggingUtil>.Instance.LogInfo("There are no more steps available for " + bot.GetText() + " in " + (currentAssignment.QuestObjectiveAssignment?.ToString() ?? "???"));
             }
 
-            BotJobAssignment? newJobAssignment = GetNewBotJobAssignment();
-            if (newJobAssignment != null)
-            {
-                return true;
-            }
-
-            return false;
+            return NewJobCreationJobRunning();
         }
 
         [Benchmark]
-        public BotJobAssignment? GetNewBotJobAssignment()
+        public bool NewJobCreationJobRunning()
         {
-            if (_botOwner == null)
+            if (assignmentCreationJob == null)
             {
-                throw new ArgumentNullException("Cannot get an assignment for a null bot");
+                return TryCreateNewJobAssignment();
             }
 
+            if (assignmentCreationJob.IsCreatingAnAssignment)
+            {
+                Singleton<LoggingUtil>.Instance.LogDebug("Waiting for an assignment to be created for " + _botOwner.GetText());
+                return true;
+            }
+
+            if (!assignmentCreationJob.NewAssignmentReady)
+            {
+                Singleton<LoggingUtil>.Instance.LogWarning("Could not create a new assignment for " + _botOwner.GetText());
+                assignmentCreationJob = null;
+                return false;
+            }
+
+            if (assignmentCreationJob.AssignmentCreationResult == null)
+            {
+                Singleton<LoggingUtil>.Instance.LogError("Created a null job assignment for " + _botOwner.GetText());
+                assignmentCreationJob = null;
+                return false;
+            }
+
+            return true;
+        }
+
+        public bool TryCreateNewJobAssignment()
+        {
             BotObjectiveManager? objectiveManager = _botOwner.GetObjectiveManager();
             if (objectiveManager == null)
             {
                 Singleton<LoggingUtil>.Instance.LogError("Cannot retrieve BotObjectiveManager for " + _botOwner.GetText());
-                return null;
+                return false;
+            }
+
+            if (!objectiveManager.IsQuestingAllowed)
+            {
+                return false;
             }
 
             // Do not select another quest objective if the bot wants to extract
             if (objectiveManager.DoesBotWantToExtract())
             {
-                return null;
+                return false;
             }
 
-            float maxDistanceBetweenExfils = Singleton<GameWorld>.Instance.GetComponent<Components.LocationData>().GetMaxDistanceBetweenExfils();
-            float minDistanceToSwitchExfil = maxDistanceBetweenExfils * Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilReachedMinFraction;
+            assignmentCreationJob = new BotJobAssignmentCreationJob(_botOwner, exfiltrationPoint);
+            StartCoroutine(assignmentCreationJob.CreateNewBotJobAssignment());
 
-            // If the bot is close to its selected exfil (only used for quest selection), select a new one
-            float? distanceToExfilPoint = objectiveManager.QuestSelector.DistanceToExfiltrationPointForQuesting();
-            if (distanceToExfilPoint.HasValue && (distanceToExfilPoint.Value < minDistanceToSwitchExfil))
-            {
-                objectiveManager.QuestSelector.SetExfiliationPointForQuesting();
-            }
-
-            // Get the bot's most recent assingment if applicable
-            BotJobAssignment? mostRecentAssignment = _botOwner.GetMostRecentJobAssignment();
-            BotQuest? quest = mostRecentAssignment?.QuestAssignment;
-            BotQuestObjective? objective = mostRecentAssignment?.QuestObjectiveAssignment;
-
-            // Clear the bot's assignment if it's been doing the same quest for too long
-            if ((quest?.HasBotBeingDoingQuestTooLong(_botOwner, out double? timeDoingQuest) == true) && (timeDoingQuest != null))
-            {
-                Singleton<LoggingUtil>.Instance.LogInfo(_botOwner.GetText() + " has been performing quest " + quest.ToString() + " for " + timeDoingQuest.Value + "s and will get a new one.");
-                quest = null;
-                objective = null;
-            }
-
-            // Try to find a quest that has at least one objective that can be assigned to the bot
-            List<BotQuest> invalidQuests = new List<BotQuest>();
-            Stopwatch timeoutMonitor = Stopwatch.StartNew();
-            do
-            {
-                // Find the nearest objective for the bot's currently assigned quest (if any)
-                objective = quest?
-                    .RemainingObjectivesForBot(_botOwner)?
-                    .Where(o => o.CanAssignBot(_botOwner))?
-                    .Where(o => o.CanBotRepeatQuestObjective(_botOwner))?
-                    .NearestToBot(_botOwner);
-
-                // Exit the loop if an objective was found for the bot
-                if (objective != null)
-                {
-                    break;
-                }
-                if (quest != null)
-                {
-                    //Singleton<LoggingUtil>.Instance.LogInfo(bot.GetText() + " cannot select quest " + quest.ToString() + " because it has no valid objectives");
-                    invalidQuests.Add(quest);
-                }
-
-                // If no objectives were found, select another quest
-                quest = GetRandomQuest(invalidQuests);
-
-                // If a quest hasn't been found within a certain amount of time, something is wrong
-                if (timeoutMonitor.ElapsedMilliseconds > Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.QuestSelectionTimeout)
-                {
-                    // First try allowing the bot to repeat quests it already completed
-                    if (_botOwner.TryArchiveRepeatableAssignments() > 0)
-                    {
-                        Singleton<LoggingUtil>.Instance.LogWarning(_botOwner.GetText() + " cannot select any quests. Trying to select a repeatable quest early instead...");
-                        continue;
-                    }
-
-                    // If there are still no quests available for the bot to select, give up trying to select one
-                    Singleton<LoggingUtil>.Instance.LogError(_botOwner.GetText() + " could not select any of the following quests: " + string.Join(", ", _botOwner.GetAllPossibleQuests()));
-                    objectiveManager.StopQuesting();
-
-                    // Try making the bot extract because it has nothing to do
-                    if (objectiveManager.BotMonitor.GetMonitor<BotExtractMonitor>().TryInstructBotToExtract())
-                    {
-                        Singleton<LoggingUtil>.Instance.LogWarning(_botOwner.GetText() + " cannot select any quests. Extracting instead...");
-                        return null;
-                    }
-
-                    Singleton<LoggingUtil>.Instance.LogError(_botOwner.GetText() + " cannot select any quests. Questing disabled.");
-                    return null;
-                }
-
-            } while (objective == null);
-
-            if (quest == null)
-            {
-                return null;
-            }
-
-            // Once a valid assignment is selected, assign it to the bot
-            BotJobAssignment assignment = new BotJobAssignment(_botOwner, quest, objective);
-            assignment.Register();
-
-            return assignment;
-        }
-
-        public BotQuest GetRandomQuest(IEnumerable<BotQuest> invalidQuests)
-        {
-            if (_botOwner == null)
-            {
-                throw new ArgumentNullException("Cannot get a quest for a null bot");
-            }
-
-            Stopwatch questSelectionTimer = Stopwatch.StartNew();
-
-            BotQuest[] assignableQuests = _botOwner.GetAllPossibleQuests()
-                .Where(q => !invalidQuests.Contains(q))
-                .ToArray();
-
-            if (!assignableQuests.Any())
-            {
-                return null!;
-            }
-
-            Vector3? vectorToExfil = VectorToExfiltrationPointForQuesting();
-
-            Dictionary<BotQuest, Configuration.MinMaxConfig> questDistanceRanges = new Dictionary<BotQuest, Configuration.MinMaxConfig>();
-            Dictionary<BotQuest, Configuration.MinMaxConfig> questExfilAngleRanges = new Dictionary<BotQuest, Configuration.MinMaxConfig>();
-
-            // Calculate the distances from the bot to all valid quest objectives and the angles between the vector to the bot's selected
-            // exfil (for questing) and the vector to each valid quest objective
-            foreach (BotQuest quest in assignableQuests)
-            {
-                IEnumerable<Vector3?> objectivePositions = quest.ValidObjectives.Select(o => o.GetFirstStepPosition());
-                IEnumerable<Vector3> validObjectivePositions = objectivePositions.Where(p => p.HasValue).Select(p => p!.Value);
-                IEnumerable<float> distancesToObjectives = validObjectivePositions.Select(p => Vector3.Distance(_botOwner.Position, p));
-
-                questDistanceRanges.Add(quest, new Configuration.MinMaxConfig(distancesToObjectives.Min(), distancesToObjectives.Max()));
-
-                if (vectorToExfil.HasValue)
-                {
-                    IEnumerable<Vector3> vectorsToObjectivePositions = validObjectivePositions.Select(p => p - _botOwner.Position);
-                    IEnumerable<float> anglesToObjectives = vectorsToObjectivePositions.Select(p => Vector3.Angle(p - _botOwner.Position, vectorToExfil.Value));
-
-                    questExfilAngleRanges.Add(quest, new Configuration.MinMaxConfig(anglesToObjectives.Min(), anglesToObjectives.Max()));
-                }
-                else
-                {
-                    questExfilAngleRanges.Add(quest, new Configuration.MinMaxConfig(0, 0));
-                }
-            }
-
-            // Calculate the maximum amount of "randomness" to apply to each quest
-            //double distanceRange = questDistanceRanges.Max(q => q.Value.Max) - questDistanceRanges.Min(q => q.Value.Min);
-            double maxDistance = questDistanceRanges.Max(o => o.Value.Max);
-            int maxRandomDistance = (int)Math.Ceiling(maxDistance * Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DistanceRandomness / 100.0);
-            float maxExfilAngle = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionMaxAngle;
-
-            int distanceRandomness = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DistanceRandomness;
-            int desirabilityRandomness = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DesirabilityRandomness;
-
-            float distanceWeighting = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DistanceWeighting;
-            float desirabilityWeighting = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DesirabilityWeighting;
-            float exfilDirectionWeighting = 0;
-
-            string locationId = Singleton<GameWorld>.Instance.GetComponent<Components.LocationData>().CurrentLocation.Id;
-            if (Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionWeighting.ContainsKey(locationId))
-            {
-                exfilDirectionWeighting = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionWeighting[locationId];
-            }
-            else if (Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionWeighting.ContainsKey("default"))
-            {
-                exfilDirectionWeighting = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionWeighting["default"];
-            }
-
-            System.Random random = new System.Random();
-            Dictionary<BotQuest, double> questDistanceFractions = questDistanceRanges
-                .ToDictionary(o => o.Key, o => 1 - (o.Value.Min + random.Next(-1 * maxRandomDistance, maxRandomDistance)) / maxDistance);
-            Dictionary<BotQuest, float> questDesirabilityFractions = questDistanceRanges
-                .ToDictionary(o => o.Key, o =>
-                (
-                    o.Key.Desirability * (o.Key.IsActiveForPlayer ? Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DesirabilityActiveQuestMultiplier : 1)
-                    + random.Next(-1 * desirabilityRandomness, desirabilityRandomness)) / 100
-                );
-            Dictionary<BotQuest, double> questExfilAngleFactor = questExfilAngleRanges
-                .ToDictionary(o => o.Key, o => Math.Max(0, o.Value.Min - maxExfilAngle) / (180 - maxExfilAngle));
-
-            IEnumerable<BotQuest> sortedQuests = questDistanceRanges
-                .OrderBy
-                (o =>
-                    (questDistanceFractions[o.Key] * distanceWeighting)
-                    + (questDesirabilityFractions[o.Key] * desirabilityWeighting)
-                    - (questExfilAngleFactor[o.Key] * exfilDirectionWeighting)
-                )
-                .Select(o => o.Key);
-
-            BotQuest selectedQuest = sortedQuests.Last();
-
-            //Singleton<LoggingUtil>.Instance.LogInfo("Distance: " + questDistanceFractions[selectedQuest] + ", Desirability: " + questDesirabilityFractions[selectedQuest] + ", Exfil Angle Factor: " + questExfilAngleFactor[selectedQuest]);
-            //Singleton<LoggingUtil>.Instance.LogInfo("Time for quest selection: " + questSelectionTimer.ElapsedMilliseconds + "ms");
-
-            return selectedQuest;
+            return true;
         }
     }
 }

--- a/Client/Components/BotQuestSelector.cs
+++ b/Client/Components/BotQuestSelector.cs
@@ -25,6 +25,8 @@ namespace QuestingBots.Components
 
         public bool NewAssignmentReady => assignmentCreationJob?.NewAssignmentReady == true;
 
+        public BotJobAssignment? GetCurrentJobAssignment() => _botOwner.GetMostRecentJobAssignment();
+
         public static BotQuestSelector GetBotQuestSelector(BotOwner botOwner)
         {
             BotQuestSelector botQuestSelector = botOwner.gameObject.GetOrAddComponent<BotQuestSelector>();
@@ -57,54 +59,61 @@ namespace QuestingBots.Components
             }
         }
 
-        public BotJobAssignment? GetCurrentJobAssignment(bool allowUpdate = true)
+        public void RefreshJobAssignment()
         {
-            bool hasNewJobAssignment = allowUpdate && DoesBotHaveNewJobAssignment();
-
-            BotJobAssignment? mostRecentAssignment = _botOwner.GetMostRecentJobAssignment();
-            if (!hasNewJobAssignment)
+            if (HasActiveAssignment(out _))
             {
-                return mostRecentAssignment;
-            }
-            
-            if (assignmentCreationJob != null)
-            {
-                return assignmentCreationJob.AssignmentCreationResult;
+                return;
             }
 
-            return mostRecentAssignment;
+            if (TryAssignNextObjectiveStep())
+            {
+                return;
+            }
+
+            if (IsNewJobCreationJobRunning())
+            {
+                Singleton<LoggingUtil>.Instance.LogDebug(_botOwner.GetText() + " is waiting for a new job assignment to be created");
+                return;
+            }
+
+            TryCreateNewJobAssignment();
         }
 
-        public bool DoesBotHaveNewJobAssignment()
+        public bool HasActiveAssignment(out BotJobAssignment? currentAssignment)
         {
-            BotJobAssignment? mostRecentAssignment = _botOwner.GetMostRecentJobAssignment();
-            if (mostRecentAssignment != null)
+            currentAssignment = _botOwner.GetMostRecentJobAssignment();
+            if (currentAssignment == null)
             {
-                // Check if the bot is currently doing an assignment
-                if (mostRecentAssignment.IsActive)
-                {
-                    return false;
-                }
-
-                // Check if more steps are available for the bot's current assignment
-                if (mostRecentAssignment.TrySetNextObjectiveStep(false))
-                {
-                    assignmentCreationJob = null;
-                    return true;
-                }
-
-                //Singleton<LoggingUtil>.Instance.LogInfo("There are no more steps available for " + bot.GetText() + " in " + (currentAssignment.QuestObjectiveAssignment?.ToString() ?? "???"));
+                return false;
             }
 
-            return NewJobCreationJobRunning();
+            return currentAssignment.IsActive;
         }
 
-        [Benchmark]
-        public bool NewJobCreationJobRunning()
+        public bool TryAssignNextObjectiveStep()
+        {
+            if (HasActiveAssignment(out BotJobAssignment? currentAssignment))
+            {
+                return false;
+            }
+
+            // Check if more steps are available for the bot's current assignment
+            if ((currentAssignment != null) && currentAssignment.TrySetNextObjectiveStep(false))
+            {
+                assignmentCreationJob = null;
+                return true;
+            }
+
+            //Singleton<LoggingUtil>.Instance.LogInfo("There are no more steps available for " + bot.GetText() + " in " + (currentAssignment.QuestObjectiveAssignment?.ToString() ?? "???"));
+            return false;
+        }
+
+        public bool IsNewJobCreationJobRunning()
         {
             if (assignmentCreationJob == null)
             {
-                return TryCreateNewJobAssignment();
+                return false;
             }
 
             if (assignmentCreationJob.IsCreatingAnAssignment)
@@ -113,25 +122,21 @@ namespace QuestingBots.Components
                 return true;
             }
 
-            if (!assignmentCreationJob.NewAssignmentReady)
-            {
-                Singleton<LoggingUtil>.Instance.LogWarning("Could not create a new assignment for " + _botOwner.GetText());
-                assignmentCreationJob = null;
-                return false;
-            }
-
-            if (assignmentCreationJob.AssignmentCreationResult == null)
-            {
-                Singleton<LoggingUtil>.Instance.LogError("Created a null job assignment for " + _botOwner.GetText());
-                assignmentCreationJob = null;
-                return false;
-            }
-
-            return true;
+            return false;
         }
 
         public bool TryCreateNewJobAssignment()
         {
+            if (assignmentCreationJob?.IsCreatingAnAssignment == true)
+            {
+                Singleton<LoggingUtil>.Instance.LogDebug("Discarding pending job assignment creation task for " + _botOwner.GetText());
+            }
+
+            if (assignmentCreationJob?.NewAssignmentReady == true)
+            {
+                //Singleton<LoggingUtil>.Instance.LogDebug("Discarding finished job assignment creation task for " + _botOwner.GetText());
+            }
+
             BotObjectiveManager? objectiveManager = _botOwner.GetObjectiveManager();
             if (objectiveManager == null)
             {

--- a/Client/Components/BotQuestSelector.cs
+++ b/Client/Components/BotQuestSelector.cs
@@ -20,7 +20,7 @@ namespace QuestingBots.Components
     public class BotQuestSelector : BehaviorExtensions.MonoBehaviourDelayedUpdate
     {
         private BotOwner _botOwner = null!;
-        private ExfiltrationPoint exfiltrationPoint = null!;
+        private ExfiltrationPoint _exfiltrationPoint = null!;
         private BotJobAssignmentCreationJob? assignmentCreationJob = null;
 
         public bool NewAssignmentReady => assignmentCreationJob?.NewAssignmentReady == true;
@@ -38,11 +38,10 @@ namespace QuestingBots.Components
         public void Init(BotOwner botOwner)
         {
             _botOwner = botOwner;
-            SetExfiliationPointForQuesting();
+            SetExfiltrationPointForQuesting();
         }
 
-        [Benchmark]
-        public void SetExfiliationPointForQuesting()
+        public void SetExfiltrationPointForQuesting()
         {
             Dictionary<ExfiltrationPoint, float> exfiltrationPointDistances = Singleton<GameWorld>.Instance.ExfiltrationController.ExfiltrationPoints
                 .ToDictionary(p => p, p => Vector3.Distance(p.transform.position, _botOwner.Position));
@@ -53,10 +52,50 @@ namespace QuestingBots.Components
                     .OrderBy(p => p.Value)
                     .Last();
 
-                exfiltrationPoint = furthestPoint.Key;
+                _exfiltrationPoint = furthestPoint.Key;
 
                 //Singleton<LoggingUtil>.Instance.LogInfo(botOwner.GetText() + " has selected " + furthestPoint.Key.Settings.Name + " as its furthest exfil point (" + furthestPoint.Value + "m)");
             }
+        }
+
+        public void RefreshExfiltrationPointForQuesting()
+        {
+            BotObjectiveManager? objectiveManager = _botOwner.GetObjectiveManager();
+            if (objectiveManager == null)
+            {
+                Singleton<LoggingUtil>.Instance.LogError("Cannot retrieve BotObjectiveManager for " + _botOwner.GetText());
+                return;
+            }
+
+            float maxDistanceBetweenExfils = Singleton<GameWorld>.Instance.GetComponent<Components.LocationData>().GetMaxDistanceBetweenExfils();
+            float minDistanceToSwitchExfil = maxDistanceBetweenExfils * Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilReachedMinFraction;
+
+            // If the bot is close to its selected exfil (only used for quest selection), select a new one
+            float? distanceToExfilPoint = DistanceToExfiltrationPointForQuesting();
+            if (distanceToExfilPoint.HasValue && (distanceToExfilPoint.Value < minDistanceToSwitchExfil))
+            {
+                objectiveManager.QuestSelector.SetExfiltrationPointForQuesting();
+            }
+        }
+
+        public float? DistanceToExfiltrationPointForQuesting()
+        {
+            if (_exfiltrationPoint == null)
+            {
+                return null;
+            }
+
+            return Vector3.Distance(_botOwner.Position, _exfiltrationPoint.transform.position);
+        }
+
+        public Vector3? VectorToExfiltrationPointForQuesting()
+        {
+            if (_exfiltrationPoint == null)
+            {
+                return null;
+            }
+
+            return _exfiltrationPoint.transform.position - _botOwner.Position;
         }
 
         public void RefreshJobAssignment()
@@ -73,7 +112,6 @@ namespace QuestingBots.Components
 
             if (IsNewJobCreationJobRunning())
             {
-                Singleton<LoggingUtil>.Instance.LogDebug(_botOwner.GetText() + " is waiting for a new job assignment to be created");
                 return;
             }
 
@@ -118,7 +156,7 @@ namespace QuestingBots.Components
 
             if (assignmentCreationJob.IsCreatingAnAssignment)
             {
-                Singleton<LoggingUtil>.Instance.LogDebug("Waiting for an assignment to be created for " + _botOwner.GetText());
+                //Singleton<LoggingUtil>.Instance.LogDebug("Waiting for an assignment to be created for " + _botOwner.GetText());
                 return true;
             }
 
@@ -155,7 +193,10 @@ namespace QuestingBots.Components
                 return false;
             }
 
-            assignmentCreationJob = new BotJobAssignmentCreationJob(_botOwner, exfiltrationPoint);
+            // If the bot is close to its originally selected exfiltration point, choose a new one to keep it moving around the map
+            RefreshExfiltrationPointForQuesting();
+
+            assignmentCreationJob = new BotJobAssignmentCreationJob(_botOwner);
             StartCoroutine(assignmentCreationJob.CreateNewBotJobAssignment());
 
             return true;

--- a/Client/Components/BotQuestSelector.cs
+++ b/Client/Components/BotQuestSelector.cs
@@ -5,7 +5,6 @@ using QuestingBots.Controllers;
 using QuestingBots.Helpers;
 using QuestingBots.Models.Questing;
 using QuestingBots.Utils;
-using QuestingBots.Utils.Benchmarking;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -21,7 +20,7 @@ namespace QuestingBots.Components
     {
         private BotOwner _botOwner = null!;
         private ExfiltrationPoint? _exfiltrationPoint = null;
-        private BotJobAssignmentCreationJob? assignmentCreationJob = null;
+        private IBotJobAssignmentCreationJob? assignmentCreationJob = null;
 
         public bool NewAssignmentReady => assignmentCreationJob?.NewAssignmentReady == true;
 
@@ -104,12 +103,18 @@ namespace QuestingBots.Components
 
         public BotJobAssignment? GetCurrentJobAssignment()
         {
-            if (NewAssignmentReady)
+            return _botOwner.GetMostRecentJobAssignment();
+        }
+
+        public void AcceptNewAssignment()
+        {
+            if (!NewAssignmentReady)
             {
-                assignmentCreationJob = null;
+                Singleton<LoggingUtil>.Instance.LogWarning(_botOwner.GetText() + " tried accepting a new assignment that was not ready");
+                return;
             }
 
-            return _botOwner.GetMostRecentJobAssignment();
+            assignmentCreationJob = null;
         }
 
         public void RefreshJobAssignment()
@@ -153,7 +158,7 @@ namespace QuestingBots.Components
             // Check if more steps are available for the bot's current assignment
             if ((currentAssignment != null) && currentAssignment.TrySetNextObjectiveStep(false))
             {
-                assignmentCreationJob = null;
+                assignmentCreationJob = new CompletedBotJobAssignmentCreationJob(currentAssignment);
                 return true;
             }
 

--- a/Client/Components/BotQuestSelector.cs
+++ b/Client/Components/BotQuestSelector.cs
@@ -101,11 +101,6 @@ namespace QuestingBots.Components
             return _exfiltrationPoint.transform.position - _botOwner.Position;
         }
 
-        public BotJobAssignment? GetCurrentJobAssignment()
-        {
-            return _botOwner.GetMostRecentJobAssignment();
-        }
-
         public void AcceptNewAssignment()
         {
             if (!NewAssignmentReady)

--- a/Client/Components/BotQuestSelector.cs
+++ b/Client/Components/BotQuestSelector.cs
@@ -20,12 +20,10 @@ namespace QuestingBots.Components
     public class BotQuestSelector : BehaviorExtensions.MonoBehaviourDelayedUpdate
     {
         private BotOwner _botOwner = null!;
-        private ExfiltrationPoint _exfiltrationPoint = null!;
+        private ExfiltrationPoint? _exfiltrationPoint = null;
         private BotJobAssignmentCreationJob? assignmentCreationJob = null;
 
         public bool NewAssignmentReady => assignmentCreationJob?.NewAssignmentReady == true;
-
-        public BotJobAssignment? GetCurrentJobAssignment() => _botOwner.GetMostRecentJobAssignment();
 
         public static BotQuestSelector GetBotQuestSelector(BotOwner botOwner)
         {
@@ -43,19 +41,25 @@ namespace QuestingBots.Components
 
         public void SetExfiltrationPointForQuesting()
         {
-            Dictionary<ExfiltrationPoint, float> exfiltrationPointDistances = Singleton<GameWorld>.Instance.ExfiltrationController.ExfiltrationPoints
-                .ToDictionary(p => p, p => Vector3.Distance(p.transform.position, _botOwner.Position));
+            float furthestExfilDistace = 0;
+            _exfiltrationPoint = null;
 
-            if (exfiltrationPointDistances.Count > 0)
+            foreach (ExfiltrationPoint exfiltrationPoint in Singleton<GameWorld>.Instance.ExfiltrationController.ExfiltrationPoints)
             {
-                KeyValuePair<ExfiltrationPoint, float> furthestPoint = exfiltrationPointDistances
-                    .OrderBy(p => p.Value)
-                    .Last();
-
-                _exfiltrationPoint = furthestPoint.Key;
-
-                //Singleton<LoggingUtil>.Instance.LogInfo(botOwner.GetText() + " has selected " + furthestPoint.Key.Settings.Name + " as its furthest exfil point (" + furthestPoint.Value + "m)");
+                float exfilDistace = Vector3.Distance(exfiltrationPoint.transform.position, _botOwner.Position);
+                if (exfilDistace > furthestExfilDistace)
+                {
+                    _exfiltrationPoint = exfiltrationPoint;
+                    furthestExfilDistace = exfilDistace;
+                }
             }
+
+            if (_exfiltrationPoint == null)
+            {
+                return;
+            }
+
+            //Singleton<LoggingUtil>.Instance.LogInfo(botOwner.GetText() + " has selected " + furthestPoint.Key.Settings.Name + " as its furthest exfil point (" + furthestPoint.Value + "m)");
         }
 
         public void RefreshExfiltrationPointForQuesting()
@@ -96,6 +100,16 @@ namespace QuestingBots.Components
             }
 
             return _exfiltrationPoint.transform.position - _botOwner.Position;
+        }
+
+        public BotJobAssignment? GetCurrentJobAssignment()
+        {
+            if (NewAssignmentReady)
+            {
+                assignmentCreationJob = null;
+            }
+
+            return _botOwner.GetMostRecentJobAssignment();
         }
 
         public void RefreshJobAssignment()

--- a/Client/Components/DebugData.cs
+++ b/Client/Components/DebugData.cs
@@ -101,7 +101,7 @@ namespace QuestingBots.Components
         {
             Singleton<LoggingUtil>.Instance.LogInfo("Loading all possible job assignments...");
 
-            IEnumerable<JobAssignment> jobAssignments = BotJobAssignmentFactory.CreateAllPossibleJobAssignments();
+            IEnumerable<JobAssignment> jobAssignments = BotJobAssignmentController.CreateAllPossibleJobAssignments();
 
             Vector3 lastPosition = Vector3.positiveInfinity;
             BotQuest lastQuest = null!;

--- a/Client/Components/DebugData.cs
+++ b/Client/Components/DebugData.cs
@@ -104,7 +104,7 @@ namespace QuestingBots.Components
             IEnumerable<JobAssignment> jobAssignments = BotJobAssignmentFactory.CreateAllPossibleJobAssignments();
 
             Vector3 lastPosition = Vector3.positiveInfinity;
-            Quest lastQuest = null!;
+            BotQuest lastQuest = null!;
             foreach (JobAssignment jobAssignment in jobAssignments)
             {
                 // Ensure the position is valid and isn't the same as the previous step in the quest objective

--- a/Client/Components/LocationData.cs
+++ b/Client/Components/LocationData.cs
@@ -76,6 +76,7 @@ namespace QuestingBots.Components
             UpdateMaxTotalBots();
 
             Singleton<GameWorld>.Instance.gameObject.GetOrAddComponent<BotLogic.HiveMind.BotHiveMindMonitor>();
+            Singleton<GameWorld>.Instance.gameObject.GetOrAddComponent<Spawning.BotGenerationManager>();
 
             if (Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.Enabled)
             {

--- a/Client/Components/LocationData.cs
+++ b/Client/Components/LocationData.cs
@@ -474,14 +474,14 @@ namespace QuestingBots.Components
             }
         }
 
-        public EFT.Interactive.Switch FindSwitch(string id)
+        public EFT.Interactive.Switch? FindSwitch(string id)
         {
             if (IdsForSwitches.ContainsKey(id))
             {
                 return IdsForSwitches[id];
             }
 
-            return null!;
+            return null;
         }
 
         private void FindAllLockedDoors()

--- a/Client/Components/QuestMinLevelFinder.cs
+++ b/Client/Components/QuestMinLevelFinder.cs
@@ -16,11 +16,11 @@ namespace QuestingBots.Components
     {
         private static Dictionary<string, int> cachedMinLevelsForQuestIds = new Dictionary<string, int>();
 
-        private Dictionary<Models.Questing.Quest, int> minLevelsForQuests = new Dictionary<Models.Questing.Quest, int>();
+        private Dictionary<Models.Questing.BotQuest, int> minLevelsForQuests = new Dictionary<Models.Questing.BotQuest, int>();
 
-        private Models.Questing.Quest targetQuest;
+        private Models.Questing.BotQuest targetQuest;
 
-        public QuestMinLevelFinder(Models.Questing.Quest _quest)
+        public QuestMinLevelFinder(Models.Questing.BotQuest _quest)
         {
             targetQuest = _quest;
         }
@@ -32,7 +32,7 @@ namespace QuestingBots.Components
 
         public int FindMinLevel() => FindMinLevel(targetQuest);
 
-        private int FindMinLevel(Models.Questing.Quest quest)
+        private int FindMinLevel(Models.Questing.BotQuest quest)
         {
             // Check if this instance has already checked for the min level of this quest
             if (minLevelsForQuests.ContainsKey(quest))
@@ -55,7 +55,7 @@ namespace QuestingBots.Components
 
         private void UpdateCache()
         {
-            foreach (Models.Questing.Quest preReqQuest in minLevelsForQuests.Keys)
+            foreach (Models.Questing.BotQuest preReqQuest in minLevelsForQuests.Keys)
             {
                 if (preReqQuest.Template == null)
                 {
@@ -66,7 +66,7 @@ namespace QuestingBots.Components
             }
         }
 
-        private void UpdateMinLevelFromQuestRequirements(Models.Questing.Quest quest)
+        private void UpdateMinLevelFromQuestRequirements(Models.Questing.BotQuest quest)
         {
             int startingMinLevel = quest.Template?.Level ?? 0;
             minLevelsForQuests.Add(quest, startingMinLevel);
@@ -109,7 +109,7 @@ namespace QuestingBots.Components
         private int GetLevelFromConditionQuest(ConditionQuest conditionQuest)
         {
             // Find the required quest
-            Models.Questing.Quest preReqQuest = BotJobAssignmentFactory.FindQuest(conditionQuest.target);
+            Models.Questing.BotQuest preReqQuest = BotJobAssignmentFactory.FindQuest(conditionQuest.target);
             if (preReqQuest == null)
             {
                 Singleton<LoggingUtil>.Instance.LogWarning("Cannot find prerequisite quest " + conditionQuest.target + " for quest " + targetQuest.GetName());
@@ -119,7 +119,7 @@ namespace QuestingBots.Components
             return FindMinLevel(preReqQuest);
         }
 
-        private void UpdateMinLevel(Models.Questing.Quest quest, int level)
+        private void UpdateMinLevel(Models.Questing.BotQuest quest, int level)
         {
             if (!minLevelsForQuests.ContainsKey(quest))
             {

--- a/Client/Components/QuestMinLevelFinder.cs
+++ b/Client/Components/QuestMinLevelFinder.cs
@@ -109,7 +109,7 @@ namespace QuestingBots.Components
         private int GetLevelFromConditionQuest(ConditionQuest conditionQuest)
         {
             // Find the required quest
-            Models.Questing.BotQuest preReqQuest = BotJobAssignmentFactory.FindQuest(conditionQuest.target);
+            Models.Questing.BotQuest preReqQuest = BotJobAssignmentController.FindQuest(conditionQuest.target);
             if (preReqQuest == null)
             {
                 Singleton<LoggingUtil>.Instance.LogWarning("Cannot find prerequisite quest " + conditionQuest.target + " for quest " + targetQuest.GetName());

--- a/Client/Components/QuestMinLevelFinder.cs
+++ b/Client/Components/QuestMinLevelFinder.cs
@@ -109,7 +109,7 @@ namespace QuestingBots.Components
         private int GetLevelFromConditionQuest(ConditionQuest conditionQuest)
         {
             // Find the required quest
-            Models.Questing.BotQuest preReqQuest = BotJobAssignmentController.FindQuest(conditionQuest.target);
+            Models.Questing.BotQuest? preReqQuest = BotJobAssignmentController.FindQuest(conditionQuest.target);
             if (preReqQuest == null)
             {
                 Singleton<LoggingUtil>.Instance.LogWarning("Cannot find prerequisite quest " + conditionQuest.target + " for quest " + targetQuest.GetName());

--- a/Client/Components/QuestPathFinder.cs
+++ b/Client/Components/QuestPathFinder.cs
@@ -66,7 +66,7 @@ namespace QuestingBots.Components
             Singleton<LoggingUtil>.Instance.LogInfo("Finding static paths...done.");
         }
 
-        private void findStaticPaths(Models.Questing.Quest quest)
+        private void findStaticPaths(Models.Questing.BotQuest quest)
         {
             if (!quest.ValidObjectives.Any())
             {
@@ -111,7 +111,7 @@ namespace QuestingBots.Components
             }
 
             // Check for static paths between each quest objective and each waypoint
-            foreach (Models.Questing.QuestObjective questObjective in quest.ValidObjectives)
+            foreach (Models.Questing.BotQuestObjective questObjective in quest.ValidObjectives)
             {
                 Vector3? firstStepPosition = questObjective.GetFirstStepPosition();
                 if (firstStepPosition == null)

--- a/Client/Components/QuestPathFinder.cs
+++ b/Client/Components/QuestPathFinder.cs
@@ -61,7 +61,7 @@ namespace QuestingBots.Components
         {
             Singleton<LoggingUtil>.Instance.LogInfo("Finding static paths...");
 
-            yield return BotJobAssignmentFactory.ProcessAllQuests(findStaticPaths);
+            yield return BotJobAssignmentController.ProcessAllQuests(findStaticPaths);
 
             Singleton<LoggingUtil>.Instance.LogInfo("Finding static paths...done.");
         }

--- a/Client/Components/QuestPathFinder.cs
+++ b/Client/Components/QuestPathFinder.cs
@@ -68,7 +68,7 @@ namespace QuestingBots.Components
 
         private void findStaticPaths(Models.Questing.BotQuest quest)
         {
-            if (!quest.ValidObjectives.Any())
+            if (!quest.GetValidObjectives().Any())
             {
                 return;
             }
@@ -111,7 +111,7 @@ namespace QuestingBots.Components
             }
 
             // Check for static paths between each quest objective and each waypoint
-            foreach (Models.Questing.BotQuestObjective questObjective in quest.ValidObjectives)
+            foreach (Models.Questing.BotQuestObjective questObjective in quest.GetValidObjectives())
             {
                 Vector3? firstStepPosition = questObjective.GetFirstStepPosition();
                 if (firstStepPosition == null)

--- a/Client/Components/Spawning/BotGenerationManager.cs
+++ b/Client/Components/Spawning/BotGenerationManager.cs
@@ -19,6 +19,19 @@ namespace QuestingBots.Components.Spawning
             activeBotGenerators.Add(botGenerator);
         }
 
+        public BotGenerator? GetActiveBotGenerator<T>() where T: BotGenerator
+        {
+            foreach (BotGenerator botGenerator in activeBotGenerators)
+            {
+                if (botGenerator is T)
+                {
+                    return botGenerator;
+                }
+            }
+
+            return null;
+        }
+
         public IEnumerable<Models.BotSpawnInfo> GetAllBotGroups()
         {
             foreach (BotGenerator botGenerator in activeBotGenerators)
@@ -75,7 +88,6 @@ namespace QuestingBots.Components.Spawning
 
         public IEnumerable<Profile> GetAllGeneratedBotProfiles()
         {
-            List<Profile> generatedBotProfiles = new List<Profile>();
             foreach (BotGenerator botGenerator in activeBotGenerators)
             {
                 if (botGenerator == null)
@@ -83,10 +95,11 @@ namespace QuestingBots.Components.Spawning
                     continue;
                 }
 
-                generatedBotProfiles.AddRange(GetGeneratedBotProfiles());
+                foreach (Profile profile in GetGeneratedBotProfiles(botGenerator))
+                {
+                    yield return profile;
+                }
             }
-
-            return generatedBotProfiles;
         }
 
         public bool AreAnyPositionsCloseToGeneratedBots(IEnumerable<Vector3> positions, float distanceFromPlayers, out float distance)
@@ -122,28 +135,27 @@ namespace QuestingBots.Components.Spawning
             return false;
         }
 
-        public IEnumerable<string> GetGeneratedBotProfileIDs()
+        public IEnumerable<string> GetGeneratedBotProfileIDs(BotGenerator botGenerator)
         {
-            return GetGeneratedBotProfiles().Select(b => b.Id);
+            return GetGeneratedBotProfiles(botGenerator).Select(b => b.Id);
         }
 
-        public IEnumerable<Profile> GetGeneratedBotProfiles()
+        public IEnumerable<Profile> GetGeneratedBotProfiles(BotGenerator botGenerator)
         {
-            List<Profile> generatedBotProfiles = new List<Profile>();
-
-            foreach (Models.BotSpawnInfo botGroup in GetAllBotGroups())
+            foreach (Models.BotSpawnInfo botGroup in botGenerator.GetBotGroups())
             {
-                generatedBotProfiles.AddRange(botGroup.Data.Profiles);
+                foreach (Profile profile in botGroup.Data.Profiles)
+                {
+                    yield return profile;
+                }
             }
-
-            return generatedBotProfiles;
         }
 
-        public bool TryGetBotGroup(BotOwner bot, out Models.BotSpawnInfo matchingGroupData)
+        public bool TryGetBotGroup(BotGenerator botGenerator, BotOwner bot, out Models.BotSpawnInfo matchingGroupData)
         {
             matchingGroupData = null!;
 
-            foreach (Models.BotSpawnInfo info in GetAllBotGroups())
+            foreach (Models.BotSpawnInfo info in botGenerator.GetBotGroups())
             {
                 foreach (Profile profile in info.Data.Profiles)
                 {
@@ -170,7 +182,7 @@ namespace QuestingBots.Components.Spawning
 
             foreach (BotGenerator botGenerator in activeBotGenerators)
             {
-                if (TryGetBotGroup(bot, out matchingGroupData) == true)
+                if (TryGetBotGroup(botGenerator, bot, out matchingGroupData) == true)
                 {
                     botSpawnInfoCache.Add(bot, matchingGroupData);
                     return true;

--- a/Client/Components/Spawning/BotGenerationManager.cs
+++ b/Client/Components/Spawning/BotGenerationManager.cs
@@ -1,0 +1,184 @@
+﻿using EFT;
+using QuestingBots.Models;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace QuestingBots.Components.Spawning
+{
+    public class BotGenerationManager : MonoBehaviour
+    {
+        private List<BotGenerator> activeBotGenerators = new List<BotGenerator>();
+        private Dictionary<BotOwner, Models.BotSpawnInfo> botSpawnInfoCache = new Dictionary<BotOwner, Models.BotSpawnInfo>();
+
+        public void AddActiveBotGenerator(BotGenerator botGenerator)
+        {
+            activeBotGenerators.Add(botGenerator);
+        }
+
+        public IEnumerable<Models.BotSpawnInfo> GetAllBotGroups()
+        {
+            foreach (BotGenerator botGenerator in activeBotGenerators)
+            {
+                foreach (BotSpawnInfo botSpawnInfo in botGenerator.GetBotGroups())
+                {
+                    yield return botSpawnInfo;
+                }
+            }
+        }
+
+        public bool IsPositionCloseToAnyGeneratedBots(Vector3 position, float distanceFromPlayers, out float distance)
+        {
+            foreach (BotGenerator botGenerator in activeBotGenerators)
+            {
+                if (botGenerator == null)
+                {
+                    continue;
+                }
+
+                if (IsPositionCloseToGeneratedBots(position, distanceFromPlayers, out distance))
+                {
+                    return true;
+                }
+            }
+
+            distance = float.MaxValue;
+            return false;
+        }
+
+        public bool AreAnyPositionsCloseToAnyGeneratedBots(IEnumerable<Vector3> positions, float distanceFromPlayers, out float distance)
+        {
+            foreach (BotGenerator botGenerator in activeBotGenerators)
+            {
+                if (botGenerator == null)
+                {
+                    continue;
+                }
+
+                if (AreAnyPositionsCloseToGeneratedBots(positions, distanceFromPlayers, out distance))
+                {
+                    return true;
+                }
+            }
+
+            distance = float.MaxValue;
+            return false;
+        }
+
+        public IEnumerable<string> GetAllGeneratedBotProfileIDs()
+        {
+            return GetAllGeneratedBotProfiles().Select(b => b.Id);
+        }
+
+        public IEnumerable<Profile> GetAllGeneratedBotProfiles()
+        {
+            List<Profile> generatedBotProfiles = new List<Profile>();
+            foreach (BotGenerator botGenerator in activeBotGenerators)
+            {
+                if (botGenerator == null)
+                {
+                    continue;
+                }
+
+                generatedBotProfiles.AddRange(GetGeneratedBotProfiles());
+            }
+
+            return generatedBotProfiles;
+        }
+
+        public bool AreAnyPositionsCloseToGeneratedBots(IEnumerable<Vector3> positions, float distanceFromPlayers, out float distance)
+        {
+            foreach (Vector3 position in positions)
+            {
+                if (IsPositionCloseToGeneratedBots(position, distanceFromPlayers, out distance))
+                {
+                    return true;
+                }
+            }
+
+            distance = float.MaxValue;
+            return false;
+        }
+
+        public bool IsPositionCloseToGeneratedBots(Vector3 position, float distanceFromPlayers, out float distance)
+        {
+            foreach (Models.BotSpawnInfo botGroup in GetAllBotGroups())
+            {
+                IEnumerable<BotOwner> aliveBots = botGroup.SpawnedBots.Where(b => (b != null) && !b.IsDead);
+                foreach (BotOwner bot in aliveBots)
+                {
+                    distance = Vector3.Distance(bot.Position, position);
+                    if (distance <= distanceFromPlayers)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            distance = float.MaxValue;
+            return false;
+        }
+
+        public IEnumerable<string> GetGeneratedBotProfileIDs()
+        {
+            return GetGeneratedBotProfiles().Select(b => b.Id);
+        }
+
+        public IEnumerable<Profile> GetGeneratedBotProfiles()
+        {
+            List<Profile> generatedBotProfiles = new List<Profile>();
+
+            foreach (Models.BotSpawnInfo botGroup in GetAllBotGroups())
+            {
+                generatedBotProfiles.AddRange(botGroup.Data.Profiles);
+            }
+
+            return generatedBotProfiles;
+        }
+
+        public bool TryGetBotGroup(BotOwner bot, out Models.BotSpawnInfo matchingGroupData)
+        {
+            matchingGroupData = null!;
+
+            foreach (Models.BotSpawnInfo info in GetAllBotGroups())
+            {
+                foreach (Profile profile in info.Data.Profiles)
+                {
+                    if (profile.Id != bot.Profile.Id)
+                    {
+                        continue;
+                    }
+
+                    matchingGroupData = info;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public bool TryGetBotGroupFromAnyGenerator(BotOwner bot, out Models.BotSpawnInfo matchingGroupData)
+        {
+            if (botSpawnInfoCache.ContainsKey(bot))
+            {
+                matchingGroupData = botSpawnInfoCache[bot];
+                return true;
+            }
+
+            foreach (BotGenerator botGenerator in activeBotGenerators)
+            {
+                if (TryGetBotGroup(bot, out matchingGroupData) == true)
+                {
+                    botSpawnInfoCache.Add(bot, matchingGroupData);
+                    return true;
+                }
+            }
+
+            matchingGroupData = null!;
+            return false;
+        }
+    }
+}

--- a/Client/Components/Spawning/BotGenerator.cs
+++ b/Client/Components/Spawning/BotGenerator.cs
@@ -29,9 +29,10 @@ namespace QuestingBots.Components.Spawning
         public int MaxAliveBots { get; protected set; } = 10;
         public float RetryTimeSeconds { get; protected set; } = 10;
 
+        protected readonly List<Models.BotSpawnInfo> BotGroups = new List<Models.BotSpawnInfo>();
+
         protected List<SpawnPointParams> PendingSpawnPoints = new List<SpawnPointParams>();
 
-        protected readonly List<Models.BotSpawnInfo> BotGroups = new List<Models.BotSpawnInfo>();
         private readonly Stopwatch retrySpawnTimer = Stopwatch.StartNew();
         private readonly Stopwatch updateTimer = Stopwatch.StartNew();
         private readonly System.Random random = new System.Random();
@@ -43,12 +44,11 @@ namespace QuestingBots.Components.Spawning
         private static Task botGenerationTask = null!;
         private static readonly List<Func<Task>> botGeneratorList = new List<Func<Task>>();
         private static readonly Dictionary<Func<BotGenerator>, bool> registeredBotGenerators = new Dictionary<Func<BotGenerator>, bool>();
-        private static readonly Dictionary<BotOwner, Models.BotSpawnInfo> botSpawnInfoCache = new Dictionary<BotOwner, Models.BotSpawnInfo>();
 
+        public IReadOnlyCollection<Models.BotSpawnInfo> GetBotGroups() => BotGroups.AsReadOnly();
+        public bool HasRemainingSpawns => !HasGeneratedBots || BotGroups.Any(g => !g.HaveAllBotsSpawned);
         public int SpawnedGroupCount => BotGroups.Count(g => g.HaveAllBotsSpawned);
         public int RemainingGroupsToSpawnCount => BotGroups.Count(g => !g.HaveAllBotsSpawned);
-        public bool HasRemainingSpawns => !HasGeneratedBots || BotGroups.Any(g => !g.HaveAllBotsSpawned);
-        public IReadOnlyCollection<Models.BotSpawnInfo> GetBotGroups() => BotGroups.ToArray();
         public int MaxBotsToGenerate => Math.Min(MaxAliveBots, MaxGeneratedBots - GeneratedBotCount);
         public int GeneratorProgress => 100 * GeneratedBotCount / MaxGeneratedBots;
 
@@ -117,11 +117,6 @@ namespace QuestingBots.Components.Spawning
             StartCoroutine(spawnBotGroups(BotGroups.ToArray()));
         }
 
-        public static void Clear()
-        {
-            botSpawnInfoCache.Clear();
-        }
-
         public static void RegisterBotGenerator<T>(bool isPScavGenerator = false) where T : BotGenerator
         {
             registeredBotGenerators.Add(() => Singleton<GameWorld>.Instance.gameObject.GetOrAddComponent<T>(), isPScavGenerator);
@@ -138,160 +133,9 @@ namespace QuestingBots.Components.Spawning
             return raidSettings.BotSettings.BotAmount != EFT.Bots.EBotAmount.NoBots;
         }
 
-        public static bool IsPositionCloseToAnyGeneratedBots(Vector3 position, float distanceFromPlayers, out float distance)
-        {
-            foreach (BotGenerator botGenerator in Singleton<GameWorld>.Instance.gameObject.GetComponents(typeof(BotGenerator)))
-            {
-                if (botGenerator == null)
-                {
-                    continue;
-                }
-
-                if (botGenerator.IsPositionCloseToGeneratedBots(position, distanceFromPlayers, out distance))
-                {
-                    return true;
-                }
-            }
-
-            distance = float.MaxValue;
-            return false;
-        }
-
-        public static bool AreAnyPositionsCloseToAnyGeneratedBots(IEnumerable<Vector3> positions, float distanceFromPlayers, out float distance)
-        {
-            foreach (BotGenerator botGenerator in Singleton<GameWorld>.Instance.gameObject.GetComponents(typeof(BotGenerator)))
-            {
-                if (botGenerator == null)
-                {
-                    continue;
-                }
-
-                if (botGenerator.AreAnyPositionsCloseToGeneratedBots(positions, distanceFromPlayers, out distance))
-                {
-                    return true;
-                }
-            }
-
-            distance = float.MaxValue;
-            return false;
-        }
-
-        public static IEnumerable<string> GetAllGeneratedBotProfileIDs()
-        {
-            return GetAllGeneratedBotProfiles().Select(b => b.Id);
-        }
-
-        public static IEnumerable<Profile> GetAllGeneratedBotProfiles()
-        {
-            List<Profile> generatedBotProfiles = new List<Profile>();
-            foreach (BotGenerator botGenerator in Singleton<GameWorld>.Instance.gameObject.GetComponents(typeof(BotGenerator)))
-            {
-                if (botGenerator == null)
-                {
-                    continue;
-                }
-
-                generatedBotProfiles.AddRange(botGenerator.GetGeneratedBotProfiles());
-            }
-
-            return generatedBotProfiles;
-        }
-
-        public bool AreAnyPositionsCloseToGeneratedBots(IEnumerable<Vector3> positions, float distanceFromPlayers, out float distance)
-        {
-            foreach (Vector3 position in positions)
-            {
-                if (IsPositionCloseToGeneratedBots(position, distanceFromPlayers, out distance))
-                {
-                    return true;
-                }
-            }
-
-            distance = float.MaxValue;
-            return false;
-        }
-
-        public bool IsPositionCloseToGeneratedBots(Vector3 position, float distanceFromPlayers, out float distance)
-        {
-            foreach (Models.BotSpawnInfo botGroup in GetBotGroups())
-            {
-                IEnumerable<BotOwner> aliveBots = botGroup.SpawnedBots.Where(b => (b != null) && !b.IsDead);
-                foreach (BotOwner bot in aliveBots)
-                {
-                    distance = Vector3.Distance(bot.Position, position);
-                    if (distance <= distanceFromPlayers)
-                    {
-                        return true;
-                    }
-                }
-            }
-
-            distance = float.MaxValue;
-            return false;
-        }
-
-        public IEnumerable<string> GetGeneratedBotProfileIDs()
-        {
-            return GetGeneratedBotProfiles().Select(b => b.Id);
-        }
-
-        public IEnumerable<Profile> GetGeneratedBotProfiles()
-        {
-            List<Profile> generatedBotProfiles = new List<Profile>();
-
-            foreach (Models.BotSpawnInfo botGroup in GetBotGroups())
-            {
-                generatedBotProfiles.AddRange(botGroup.Data.Profiles);
-            }
-
-            return generatedBotProfiles;
-        }
-
-        public bool TryGetBotGroup(BotOwner bot, out Models.BotSpawnInfo matchingGroupData)
-        {
-            matchingGroupData = null!;
-
-            foreach (Models.BotSpawnInfo info in BotGroups)
-            {
-                foreach (Profile profile in info.Data.Profiles)
-                {
-                    if (profile.Id != bot.Profile.Id)
-                    {
-                        continue;
-                    }
-
-                    matchingGroupData = info;
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
         public void AddNewBotGroup(Models.BotSpawnInfo newGroup)
         {
             BotGroups.Add(newGroup);
-        }
-
-        public static bool TryGetBotGroupFromAnyGenerator(BotOwner bot, out Models.BotSpawnInfo matchingGroupData)
-        {
-            if (botSpawnInfoCache.ContainsKey(bot))
-            {
-                matchingGroupData = botSpawnInfoCache[bot];
-                return true;
-            }
-
-            foreach (BotGenerator botGenerator in Singleton<GameWorld>.Instance.gameObject.GetComponents(typeof(BotGenerator)))
-            {
-                if (botGenerator?.TryGetBotGroup(bot, out matchingGroupData) == true)
-                {
-                    botSpawnInfoCache.Add(bot, matchingGroupData);
-                    return true;
-                }
-            }
-
-            matchingGroupData = null!;
-            return false;
         }
 
         public IReadOnlyCollection<BotOwner> GetSpawnGroupMembers(BotOwner bot)
@@ -390,6 +234,7 @@ namespace QuestingBots.Components.Spawning
         public static void RunBotGenerationTasks()
         {
             RaidSettings raidSettings = Singleton<GameWorld>.Instance.GetComponent<LocationData>().CurrentRaidSettings;
+            BotGenerationManager botGenerationManager = Singleton<GameWorld>.Instance.GetComponent<BotGenerationManager>();
 
             foreach (Func<BotGenerator> registerBotGenerator in registeredBotGenerators.Keys)
             {
@@ -399,7 +244,8 @@ namespace QuestingBots.Components.Spawning
                     continue;
                 }
 
-                registerBotGenerator();
+                BotGenerator botGenerator = registerBotGenerator();
+                botGenerationManager.AddActiveBotGenerator(botGenerator);
             }
 
             botGenerationTask = runBotGenerationTasks();

--- a/Client/Components/Spawning/BotGenerator.cs
+++ b/Client/Components/Spawning/BotGenerator.cs
@@ -204,13 +204,16 @@ namespace QuestingBots.Components.Spawning
 
         public IEnumerable<BotOwner> AliveBots()
         {
-            List<BotOwner> aliveBots = new List<BotOwner>();
             foreach (Models.BotSpawnInfo botSpawnInfo in BotGroups)
             {
-                aliveBots.AddRange(botSpawnInfo.SpawnedBots.Where(b => (b != null) && !b.IsDead));
+                IEnumerable<BotOwner> aliveBots = botSpawnInfo.SpawnedBots
+                    .Where(b => (b != null) && !b.IsDead);
+                
+                foreach (BotOwner aliveBot in aliveBots)
+                {
+                    yield return aliveBot;
+                }
             }
-
-            return aliveBots;
         }
 
         public bool CanSpawnAdditionalBots() => BotsAllowedToSpawnForGeneratorType() > 0;

--- a/Client/Components/Spawning/PMCGenerator.cs
+++ b/Client/Components/Spawning/PMCGenerator.cs
@@ -93,7 +93,7 @@ namespace QuestingBots.Components.Spawning
             EPlayerSideMask playerMask = RaidHelpers.IsBeginningOfRaid() ? EPlayerSideMask.Pmc : EPlayerSideMask.All;
             float minDistanceFromOtherPlayers = GetMinSpawnDistanceFromOtherPlayers(Singleton<ConfigUtil>.Instance.CurrentConfig.BotSpawns.PMCs) + 5;
 
-            string[] allGeneratedProfileIDs = GetAllGeneratedBotProfileIDs().ToArray();
+            string[] allGeneratedProfileIDs = Singleton<GameWorld>.Instance.GetComponent<BotGenerationManager>().GetAllGeneratedBotProfileIDs().ToArray();
             Vector3[] positionsToAvoid = Singleton<GameWorld>.Instance.AllAlivePlayersList
                 .Where(p => !p.IsAI || allGeneratedProfileIDs.Contains(p.ProfileId))
                 .Select(p => p.Position)

--- a/Client/Components/Spawning/PScavGenerator.cs
+++ b/Client/Components/Spawning/PScavGenerator.cs
@@ -113,7 +113,7 @@ namespace QuestingBots.Components.Spawning
             float minDistanceFromOtherPlayers = Singleton<ConfigUtil>.Instance.CurrentConfig.BotSpawns.PScavs.MinDistanceFromPlayersDuringRaidFactory + 5;
             Components.LocationData locationData = Singleton<GameWorld>.Instance.GetComponent<Components.LocationData>();
 
-            string[] allGeneratedProfileIDs = GetAllGeneratedBotProfileIDs().ToArray();
+            string[] allGeneratedProfileIDs = Singleton<GameWorld>.Instance.GetComponent<BotGenerationManager>().GetAllGeneratedBotProfileIDs().ToArray();
             Vector3[] positionsToAvoid = Singleton<GameWorld>.Instance.AllAlivePlayersList
                 .Where(p => !p.IsAI || allGeneratedProfileIDs.Contains(p.ProfileId))
                 .Select(p => p.Position)
@@ -144,7 +144,7 @@ namespace QuestingBots.Components.Spawning
             // Ensure none of the spawn points are too close to other players or bots
             IEnumerable<Vector3> spawnPositionsForGroup = spawnPointsForGroup.Select(p => p.Position.ToUnityVector3());
             float minSpawnDistance = GetMinSpawnDistanceFromOtherPlayers(Singleton<ConfigUtil>.Instance.CurrentConfig.BotSpawns.PScavs);
-            if (AreAnyPositionsCloseToAnyGeneratedBots(spawnPositionsForGroup, minSpawnDistance, out float distance))
+            if (Singleton<GameWorld>.Instance.GetComponent<BotGenerationManager>().AreAnyPositionsCloseToAnyGeneratedBots(spawnPositionsForGroup, minSpawnDistance, out float distance))
             {
                 Singleton<LoggingUtil>.Instance.LogWarning("Cannot spawn " + BotTypeName + " group at " + spawnPoint.Value.Position.ToUnityVector3().ToString() + ". Another player is " + distance + "m away.");
                 return Enumerable.Empty<Vector3>();

--- a/Client/Controllers/BotJobAssignmentController.cs
+++ b/Client/Controllers/BotJobAssignmentController.cs
@@ -18,7 +18,7 @@ using UnityEngine;
 
 namespace QuestingBots.Controllers
 {
-    public static class BotJobAssignmentFactory
+    public static class BotJobAssignmentController
     {
         private static CoroutineExtensions.EnumeratorWithTimeLimit enumeratorWithTimeLimit = new CoroutineExtensions.EnumeratorWithTimeLimit(Singleton<ConfigUtil>.Instance.CurrentConfig.MaxCalcTimePerFrame);
         private static List<BotQuest> allQuests = new List<BotQuest>();
@@ -253,7 +253,7 @@ namespace QuestingBots.Controllers
             return quest.AllObjectives.Where(o => !matchingAssignments.Any(a => a.QuestObjectiveAssignment == o));
         }
 
-        public static BotQuestObjective NearestToBot(this IEnumerable<BotQuestObjective> objectives, BotOwner bot)
+        public static BotQuestObjective? NearestToBot(this IEnumerable<BotQuestObjective> objectives, BotOwner bot)
         {
             Dictionary<BotQuestObjective, float> objectiveDistances = new Dictionary<BotQuestObjective, float>();
             foreach (BotQuestObjective objective in objectives)
@@ -269,7 +269,7 @@ namespace QuestingBots.Controllers
 
             if (objectiveDistances.Count == 0)
             {
-                return null!;
+                return null;
             }
 
             return objectiveDistances.OrderBy(i => i.Value).First().Key;

--- a/Client/Controllers/BotJobAssignmentController.cs
+++ b/Client/Controllers/BotJobAssignmentController.cs
@@ -15,6 +15,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using UnityEngine;
+using static Assets.CommonAssets.Scripts.Utilities.ColliderExtendedDebug;
 
 namespace QuestingBots.Controllers
 {
@@ -89,15 +90,17 @@ namespace QuestingBots.Controllers
             allQuests.Add(quest);
         }
 
-        public static BotQuest FindQuest(string questID)
+        public static BotQuest? FindQuest(string questID)
         {
-            IEnumerable<BotQuest> matchingQuests = allQuests.Where(q => q.Template?.Id == questID);
-            if (matchingQuests.Count() == 1)
+            foreach (BotQuest quest in allQuests)
             {
-                return matchingQuests.First();
+                if (quest.Template?.Id == questID)
+                {
+                    return quest;
+                }
             }
 
-            return null!;
+            return null;
         }
 
         public static void RemoveBlacklistedQuestObjectives(string locationId)
@@ -161,13 +164,35 @@ namespace QuestingBots.Controllers
         {
             int botGroupSize = BotLogic.HiveMind.BotHiveMindMonitor.GetFollowers(bot).Count + 1;
 
-            return allQuests
-                .Where(q => q.Desirability != 0)
-                .Where(q => q.NumberOfValidObjectives > 0)
-                .Where(q => q.MaxBotsInGroup >= botGroupSize)
-                .Where(q => q.CanMoreBotsDoQuest())
-                .Where(q => q.CanAssignToBot(bot))
-                .ToArray();
+            foreach (BotQuest quest in allQuests)
+            {
+                if (quest.Desirability <= 0)
+                {
+                    continue;
+                }
+
+                if (quest.NumberOfValidObjectives() == 0)
+                {
+                    continue;
+                }
+
+                if (botGroupSize > quest.MaxBotsInGroup)
+                {
+                    continue;
+                }
+
+                if (!quest.CanMoreBotsDoQuest())
+                {
+                    continue;
+                }
+
+                if (!quest.CanAssignToBot(bot))
+                {
+                    continue;
+                }
+
+                yield return quest;
+            }
         }
 
         public static void FailAllJobAssignmentsForBot(string botID)
@@ -177,8 +202,13 @@ namespace QuestingBots.Controllers
                 return;
             }
 
-            foreach (BotJobAssignment assignment in botJobAssignments[botID].Where(a => a.IsActive))
+            foreach (BotJobAssignment assignment in botJobAssignments[botID])
             {
+                if (!assignment.IsActive)
+                {
+                    continue;
+                }
+
                 assignment.Fail();
             }
         }
@@ -212,21 +242,43 @@ namespace QuestingBots.Controllers
 
         public static int NumberOfActiveBots(this BotQuest quest)
         {
-            float pendingTimeLimit = 0.3f;
-
             int num = 0;
-            foreach (string id in botJobAssignments.Keys)
+            foreach (List<BotJobAssignment> botAssignmentList in botJobAssignments.Values)
             {
-                num += botJobAssignments[id]
-                    .Where(a => a.StartTime.HasValue)
-                    .Where(a => (a.Status == JobAssignmentStatus.Active) || ((a.Status == JobAssignmentStatus.Pending) && (a?.TimeSinceStarted() < pendingTimeLimit)))
-                    .Where(a => a.QuestAssignment == quest)
-                    .Count();
+                foreach (BotJobAssignment assignment in botAssignmentList)
+                {
+                    if (assignment.QuestAssignment != quest)
+                    {
+                        continue;
+                    }
+
+                    if (!assignment.IsActiveForAssignedBot())
+                    {
+                        continue;
+                    }
+
+                    num++;
+                }
             }
 
             //Singleton<LoggingUtil>.Instance.LogInfo("Bots doing " + quest.ToString() + ": " + num);
-
             return num;
+        }
+
+        private const float PENDING_STATUS_TIME_LIMIT = 0.3f;
+        public static bool IsActiveForAssignedBot(this BotJobAssignment botAssignment)
+        {
+            if (!botAssignment.IsActive)
+            {
+                return false;
+            }
+
+            if ((botAssignment.Status == JobAssignmentStatus.Pending) && (botAssignment.TimeSinceStarted() >= PENDING_STATUS_TIME_LIMIT))
+            {
+                return false;
+            }
+
+            return true;
         }
 
         public static IEnumerable<BotQuestObjective> RemainingObjectivesForBot(this BotQuest quest, BotOwner bot)
@@ -241,38 +293,63 @@ namespace QuestingBots.Controllers
                 throw new ArgumentNullException("Quest is null", nameof(quest));
             }
 
-            if (!botJobAssignments.ContainsKey(bot.Profile.Id))
+            foreach (BotQuestObjective objective in quest.AllObjectives)
             {
-                return quest.AllObjectives;
-            }
+                if (!botJobAssignments.ContainsKey(bot.Profile.Id))
+                {
+                    yield return objective;
+                    continue;
+                }
 
-            IEnumerable<BotJobAssignment> matchingAssignments = botJobAssignments[bot.Profile.Id]
-                .Where(a => a.QuestAssignment == quest)
-                .Where(a => a.Status != JobAssignmentStatus.Archived);
-
-            return quest.AllObjectives.Where(o => !matchingAssignments.Any(a => a.QuestObjectiveAssignment == o));
-        }
-
-        public static BotQuestObjective? NearestToBot(this IEnumerable<BotQuestObjective> objectives, BotOwner bot)
-        {
-            Dictionary<BotQuestObjective, float> objectiveDistances = new Dictionary<BotQuestObjective, float>();
-            foreach (BotQuestObjective objective in objectives)
-            {
-                Vector3? firstStepPosition = objective.GetFirstStepPosition();
-                if (!firstStepPosition.HasValue)
+                if (botJobAssignments[bot.Profile.Id].HasMatchingUnArchivedAssignment(quest, objective))
                 {
                     continue;
                 }
 
-                objectiveDistances.Add(objective, Vector3.Distance(bot.Position, firstStepPosition.Value));
+                yield return objective;
             }
+        }
 
-            if (objectiveDistances.Count == 0)
+        public static bool HasMatchingUnArchivedAssignment(this IEnumerable<BotJobAssignment> assignments, BotQuest quest, BotQuestObjective objective)
+        {
+            foreach (BotJobAssignment assignment in assignments)
             {
-                return null;
+                if (assignment.Status == JobAssignmentStatus.Archived)
+                {
+                    continue;
+                }
+
+                if ((assignment.QuestAssignment == quest) && (assignment.QuestObjectiveAssignment == objective))
+                {
+                    return true;
+                }
             }
 
-            return objectiveDistances.OrderBy(i => i.Value).First().Key;
+            return false;
+        }
+
+        public static BotQuestObjective? NearestToBot(this IEnumerable<BotQuestObjective> objectives, BotOwner bot)
+        {
+            BotQuestObjective? nearestObjective = null;
+            float nearestObjectiveDistance = float.MaxValue;
+
+            foreach (BotQuestObjective objective in objectives)
+            {
+                Vector3? firstStepPosition = objective.GetFirstStepPosition();
+                if (firstStepPosition == null)
+                {
+                    continue;
+                }
+
+                float objectiveDistance = Vector3.Distance(bot.Position, firstStepPosition.Value);
+                if (objectiveDistance < nearestObjectiveDistance)
+                {
+                    nearestObjective = objective;
+                    nearestObjectiveDistance = objectiveDistance;
+                }
+            }
+
+            return nearestObjective;
         }
 
         public static DateTime? TimeWhenLastEndedForBot(this BotQuest quest, BotOwner bot)
@@ -283,18 +360,28 @@ namespace QuestingBots.Controllers
             }
 
             // Find all of the bot's assignments with this quest that have not been archived yet
-            IEnumerable<BotJobAssignment> matchingAssignments = botJobAssignments[bot.Profile.Id]
-                .Where(a => a.QuestAssignment == quest)
-                .Where(a => a.Status != JobAssignmentStatus.Archived)
-                .Reverse<BotJobAssignment>()
-                .SkipWhile(a => !a.EndTime.HasValue);
-
-            if (!matchingAssignments.Any())
+            DateTime? endTime = null;
+            foreach (BotJobAssignment assignment in botJobAssignments[bot.Profile.Id])
             {
-                return null;
+                if (assignment.QuestAssignment != quest)
+                {
+                    continue;
+                }
+
+                if (assignment.Status == JobAssignmentStatus.Archived)
+                {
+                    continue;
+                }
+
+                if (assignment.EndTime == null)
+                {
+                    continue;
+                }
+
+                endTime = assignment.EndTime;
             }
 
-            return matchingAssignments.First().EndTime;
+            return endTime;
         }
 
         public static double? ElapsedTimeWhenLastEndedForBot(this BotQuest quest, BotOwner bot)
@@ -315,17 +402,18 @@ namespace QuestingBots.Controllers
                 return null;
             }
 
-            // If the bot is currently doing this quest, find the time it first started
-            IEnumerable<BotJobAssignment> matchingAssignments = botJobAssignments[bot.Profile.Id]
-                .Reverse<BotJobAssignment>()
-                .TakeWhile(a => a.QuestAssignment == quest);
-
-            if (!matchingAssignments.Any())
+            DateTime? endTime = null;
+            for (int i = botJobAssignments[bot.Profile.Id].Count - 1; i >= 0; i--)
             {
-                return null;
+                if (botJobAssignments[bot.Profile.Id][i].QuestAssignment != quest)
+                {
+                    break;
+                }
+
+                endTime = botJobAssignments[bot.Profile.Id][i].EndTime;
             }
 
-            return matchingAssignments.Last().EndTime;
+            return endTime;
         }
 
         public static double? ElapsedTimeSinceBotStarted(this BotQuest quest, BotOwner bot)
@@ -358,22 +446,16 @@ namespace QuestingBots.Controllers
                 return false;
             }
 
-            // If the bot has never been assigned a job, it should be able to do the quest
-            // TO DO: Could this return a false positive?
-            if (!botJobAssignments.ContainsKey(bot.Profile.Id))
-            {
-                return true;
-            }
-
             // Ensure the bot can do at least one of the objectives
-            if (!quest.AllObjectives.Any(o => o.CanAssignBot(bot)))
+            if (!quest.CanAssignAnObjectiveToBot(bot))
             {
                 //Singleton<LoggingUtil>.Instance.LogInfo("Cannot assign " + bot.GetText() + " to any objectives in quest " + quest.ToString());
                 return false;
             }
 
-            if (quest.HasBotBeingDoingQuestTooLong(bot, out double? timeDoingQuest))
+            if (quest.HasBotBeingDoingQuestTooLong(bot, out double? time) && (time != null))
             {
+                //Singleton<LoggingUtil>.Instance.LogInfo(bot.GetText() + " has been doing quest " + quest.ToString() + " for " + time + "s");
                 return false;
             }
 
@@ -383,10 +465,25 @@ namespace QuestingBots.Controllers
                 return true;
             }
 
+            Singleton<LoggingUtil>.Instance.LogInfo(bot.GetText() + " has no remaining objectives for quest " + quest.ToString());
+
             // Check if enough time has elasped from the bot's last assignment in the quest
             if (quest.TryArchiveIfBotCanRepeat(bot))
             {
                 return true;
+            }
+
+            return false;
+        }
+
+        public static bool CanAssignAnObjectiveToBot(this BotQuest quest, BotOwner bot)
+        {
+            foreach (BotQuestObjective objective in quest.AllObjectives)
+            {
+                if (objective.CanAssignBot(bot))
+                {
+                    return true;
+                }
             }
 
             return false;
@@ -400,53 +497,73 @@ namespace QuestingBots.Controllers
             }
 
             double? timeSinceQuestEnded = quest.ElapsedTimeWhenLastEndedForBot(bot);
-            if (timeSinceQuestEnded.HasValue && (timeSinceQuestEnded >= Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuestingRequirements.RepeatQuestDelay))
-            {
-                Singleton<LoggingUtil>.Instance.LogInfo(bot.GetText() + " is now allowed to repeat quest " + quest.ToString());
-
-                IEnumerable<BotJobAssignment> matchingAssignments = botJobAssignments[bot.Profile.Id]
-                    .Where(a => a.QuestAssignment == quest);
-
-                foreach (BotJobAssignment assignment in matchingAssignments)
-                {
-                    assignment.Archive();
-                }
-
-                return true;
-            }
-
-            return false;
-        }
-
-        public static int TryArchiveRepeatableAssignments(this BotOwner bot)
-        {
-            BotJobAssignment[] matchingAssignments = botJobAssignments[bot.Profile.Id]
-                    .Where(a => a.QuestAssignment.IsRepeatable)
-                    .Where(a => a.Status == JobAssignmentStatus.Completed)
-                    .ToArray();
-
-            matchingAssignments.ExecuteForEach(a => a.Archive());
-
-            return matchingAssignments.Length;
-        }
-
-        public static bool CanBotRepeatQuestObjective(this BotQuestObjective objective, BotOwner bot)
-        {
-            IEnumerable<BotJobAssignment> matchingAssignments = botJobAssignments[bot.Profile.Id]
-                .Where(a => a.QuestObjectiveAssignment == objective);
-
-            if (!matchingAssignments.Any())
-            {
-                return true;
-            }
-
-            // If the assignment hasn't been archived yet, not enough time has elapsed to repeat it
-            if (!objective.IsRepeatable && matchingAssignments.Any(a => a.Status == JobAssignmentStatus.Completed))
+            if (!timeSinceQuestEnded.HasValue || (timeSinceQuestEnded < Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuestingRequirements.RepeatQuestDelay))
             {
                 return false;
             }
 
-            return objective.IsRepeatable && matchingAssignments.All(a => a.Status == JobAssignmentStatus.Archived);
+            Singleton<LoggingUtil>.Instance.LogInfo(bot.GetText() + " is now allowed to repeat quest " + quest.ToString());
+
+            foreach (BotJobAssignment assignment in botJobAssignments[bot.Profile.Id])
+            {
+                if (assignment.QuestAssignment != quest)
+                {
+                    continue;
+                }
+
+                assignment.Archive();
+            }
+
+            return true;
+        }
+
+        public static int TryArchiveRepeatableAssignments(this BotOwner bot)
+        {
+            int archivedQuests = 0;
+            foreach (BotJobAssignment assignment in botJobAssignments[bot.Profile.Id])
+            {
+                if (!assignment.QuestAssignment.IsRepeatable)
+                {
+                    continue;
+                }
+
+                if (assignment.Status != JobAssignmentStatus.Completed)
+                {
+                    continue;
+                }
+
+                assignment.Archive();
+                archivedQuests++;
+            }
+
+            return archivedQuests;
+        }
+
+        public static bool CanBotSelectQuestObjective(this BotQuestObjective objective, BotOwner bot)
+        {
+            List<BotJobAssignment> matchingAssignments = botJobAssignments[bot.Profile.Id];
+            if (matchingAssignments.Count == 0)
+            {
+                return true;
+            }
+
+            bool allArchived = true;
+            foreach (BotJobAssignment assignment in matchingAssignments)
+            {
+                if (assignment.QuestObjectiveAssignment != objective)
+                {
+                    continue;
+                }
+
+                if (!objective.IsRepeatable && (assignment.Status == JobAssignmentStatus.Completed))
+                {
+                    return false;
+                }
+
+                allArchived = allArchived & assignment.Status == JobAssignmentStatus.Archived;
+            }
+
+            return objective.IsRepeatable && allArchived;
         }
 
         public static bool HasBotBeingDoingQuestTooLong(this BotQuest quest, BotOwner bot, out double? time)
@@ -492,7 +609,7 @@ namespace QuestingBots.Controllers
             botJobAssignments[assignment.BotOwner.Profile.Id].Add(assignment);
         }
 
-        public static IEnumerable<BotJobAssignment> GetAllQuests(this BotOwner bot)
+        public static IEnumerable<BotJobAssignment> GetAllQuestAssignments(this BotOwner bot)
         {
             if (!botJobAssignments.ContainsKey(bot.Profile.Id))
             {
@@ -504,7 +621,15 @@ namespace QuestingBots.Controllers
 
         public static IEnumerable<BotJobAssignment> GetCompletedOrAchivedQuests(this BotOwner bot)
         {
-            return bot.GetAllQuests().Where(a => a.IsCompletedOrArchived);
+            foreach (BotJobAssignment assignment in bot.GetAllQuestAssignments())
+            {
+                if (!assignment.IsCompletedOrArchived)
+                {
+                    continue;
+                }
+
+                yield return assignment;
+            }
         }
 
         public static int NumberOfCompletedOrAchivedQuests(this BotOwner bot)
@@ -644,7 +769,7 @@ namespace QuestingBots.Controllers
 
             foreach (BotQuest quest in allQuests)
             {
-                foreach (BotQuestObjective objective in quest.ValidObjectives)
+                foreach (BotQuestObjective objective in quest.GetValidObjectives())
                 {
                     foreach (BotQuestObjectiveStep step in objective.AllSteps)
                     {
@@ -668,7 +793,7 @@ namespace QuestingBots.Controllers
                     continue;
                 }
 
-                foreach (BotQuestObjective objective in quest.ValidObjectives)
+                foreach (BotQuestObjective objective in quest.GetValidObjectives())
                 {
                     Vector3? firstStepPosition = objective.GetFirstStepPosition();
                     if (!firstStepPosition.HasValue)

--- a/Client/Controllers/BotJobAssignmentController.cs
+++ b/Client/Controllers/BotJobAssignmentController.cs
@@ -606,6 +606,8 @@ namespace QuestingBots.Controllers
 
         public static void Register(this BotJobAssignment assignment)
         {
+            Singleton<LoggingUtil>.Instance.LogDebug("Registered assignment " + assignment.ToString() + " for " + assignment.BotOwner.GetText());
+
             assignment.BotOwner.InitializeBotJobAssignmentsList();
             botJobAssignments[assignment.BotOwner.Profile.Id].Add(assignment);
         }

--- a/Client/Controllers/BotJobAssignmentController.cs
+++ b/Client/Controllers/BotJobAssignmentController.cs
@@ -540,14 +540,15 @@ namespace QuestingBots.Controllers
 
         public static bool CanBotSelectQuestObjective(this BotQuestObjective objective, BotOwner bot)
         {
-            List<BotJobAssignment> matchingAssignments = botJobAssignments[bot.Profile.Id];
-            if (matchingAssignments.Count == 0)
+            List<BotJobAssignment> botAssignments = botJobAssignments[bot.Profile.Id];
+            if (botAssignments.Count == 0)
             {
                 return true;
             }
 
             bool allArchived = true;
-            foreach (BotJobAssignment assignment in matchingAssignments)
+            int matchingAssignments = 0;
+            foreach (BotJobAssignment assignment in botAssignments)
             {
                 if (assignment.QuestObjectiveAssignment != objective)
                 {
@@ -560,9 +561,10 @@ namespace QuestingBots.Controllers
                 }
 
                 allArchived = allArchived & assignment.Status == JobAssignmentStatus.Archived;
+                matchingAssignments++;
             }
 
-            return objective.IsRepeatable && allArchived;
+            return matchingAssignments > 0 ? objective.IsRepeatable && allArchived : true;
         }
 
         public static bool HasBotBeingDoingQuestTooLong(this BotQuest quest, BotOwner bot, out double? time)
@@ -822,14 +824,13 @@ namespace QuestingBots.Controllers
                 return;
             }
 
-            BotJobAssignment? botJobAssignment = botObjectiveManager.QuestSelector.GetCurrentJobAssignment();
-            if (botJobAssignment?.QuestAssignment == null)
+            if (botObjectiveManager.CurrentAssignment == null)
             {
                 return;
             }
 
             int botGroupSize = BotLogic.HiveMind.BotHiveMindMonitor.GetFollowers(bot).Count + 1;
-            if (botGroupSize > botJobAssignment.QuestAssignment.MaxBotsInGroup)
+            if (botGroupSize > botObjectiveManager.CurrentAssignment.QuestAssignment.MaxBotsInGroup)
             {
                 if (botObjectiveManager.TryChangeObjective())
                 {
@@ -837,7 +838,7 @@ namespace QuestingBots.Controllers
                 }
                 else
                 {
-                    Singleton<LoggingUtil>.Instance.LogError("Cannot select new quest for " + bot.GetText() + ". It has too many followers for quest " + botJobAssignment.QuestAssignment.ToString());
+                    Singleton<LoggingUtil>.Instance.LogError("Cannot select new quest for " + bot.GetText() + ". It has too many followers for quest " + botObjectiveManager.CurrentAssignment.QuestAssignment.ToString());
                 }
             }
         }

--- a/Client/Controllers/BotJobAssignmentController.cs
+++ b/Client/Controllers/BotJobAssignmentController.cs
@@ -15,7 +15,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using UnityEngine;
-using static Assets.CommonAssets.Scripts.Utilities.ColliderExtendedDebug;
 
 namespace QuestingBots.Controllers
 {
@@ -465,7 +464,7 @@ namespace QuestingBots.Controllers
                 return true;
             }
 
-            Singleton<LoggingUtil>.Instance.LogInfo(bot.GetText() + " has no remaining objectives for quest " + quest.ToString());
+            //Singleton<LoggingUtil>.Instance.LogInfo(bot.GetText() + " has no remaining objectives for quest " + quest.ToString());
 
             // Check if enough time has elasped from the bot's last assignment in the quest
             if (quest.TryArchiveIfBotCanRepeat(bot))

--- a/Client/Controllers/BotJobAssignmentFactory.cs
+++ b/Client/Controllers/BotJobAssignmentFactory.cs
@@ -1,21 +1,21 @@
 ﻿using Comfort.Common;
 using Diz.Utils;
 using EFT;
-using QuestingBots.BotLogic.BotMonitor.Monitors;
 using QuestingBots.Components;
 using QuestingBots.Components.Spawning;
 using QuestingBots.Helpers;
 using QuestingBots.Models.Questing;
 using QuestingBots.Utils;
-using QuestingBots.Utils.Benchmarking;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using UnityEngine;
+using static Assets.CommonAssets.Scripts.Utilities.ColliderExtendedDebug;
 
 namespace QuestingBots.Controllers
 {
@@ -156,6 +156,19 @@ namespace QuestingBots.Controllers
                     }
                 }
             }
+        }
+
+        public static IEnumerable<BotQuest> GetAllPossibleQuests(this BotOwner bot)
+        {
+            int botGroupSize = BotLogic.HiveMind.BotHiveMindMonitor.GetFollowers(bot).Count + 1;
+
+            return allQuests
+                .Where(q => q.Desirability != 0)
+                .Where(q => q.NumberOfValidObjectives > 0)
+                .Where(q => q.MaxBotsInGroup >= botGroupSize)
+                .Where(q => q.CanMoreBotsDoQuest())
+                .Where(q => q.CanAssignToBot(bot))
+                .ToArray();
         }
 
         public static void FailAllJobAssignmentsForBot(string botID)
@@ -448,306 +461,36 @@ namespace QuestingBots.Controllers
             return false;
         }
 
-        public static BotJobAssignment? GetCurrentJobAssignment(this BotOwner bot, bool allowUpdate = true)
+        public static ReadOnlyCollection<BotJobAssignment> GetAllBotJobAssignments(this BotOwner bot)
+        {
+            bot.InitializeBotJobAssignmentsList();
+            return botJobAssignments[bot.Profile.Id].AsReadOnly();
+        }
+
+        private static void InitializeBotJobAssignmentsList(this BotOwner bot)
         {
             if (!botJobAssignments.ContainsKey(bot.Profile.Id))
             {
                 botJobAssignments.Add(bot.Profile.Id, new List<BotJobAssignment>());
             }
+        }
 
-            if (allowUpdate && DoesBotHaveNewJobAssignment(bot))
-            {
-                Singleton<LoggingUtil>.Instance.LogInfo("Bot " + bot.GetText() + " is now doing " + botJobAssignments[bot.Profile.Id].Last().ToString());
-
-                if (botJobAssignments[bot.Profile.Id].Count > 1)
-                {
-                    BotJobAssignment lastAssignment = botJobAssignments[bot.Profile.Id].TakeLast(2).First();
-                    Singleton<LoggingUtil>.Instance.LogDebug("Bot " + bot.GetText() + " was previously doing " + lastAssignment.ToString());
-
-                    //double? timeSinceBotStartedQuest = lastAssignment.QuestAssignment.ElapsedTimeSinceBotStarted(bot);
-                    //double? timeSinceBotLastFinishedQuest = lastAssignment.QuestAssignment.ElapsedTimeWhenLastEndedForBot(bot);
-                    //string startedTimeText = timeSinceBotStartedQuest.HasValue ? timeSinceBotStartedQuest.Value.ToString() : "N/A";
-                    //string lastFinishedTimeText = timeSinceBotLastFinishedQuest.HasValue ? timeSinceBotLastFinishedQuest.Value.ToString() : "N/A";
-                    //Singleton<LoggingUtil>.Instance.LogInfo("Time since first objective ended: " + startedTimeText + ", Time since last objective ended: " + lastFinishedTimeText);
-                }
-            }
+        public static BotJobAssignment? GetMostRecentJobAssignment(this BotOwner bot)
+        {
+            bot.InitializeBotJobAssignmentsList();
 
             if (botJobAssignments[bot.Profile.Id].Count > 0)
             {
                 return botJobAssignments[bot.Profile.Id].Last();
             }
 
-            if (allowUpdate)
-            {
-                Singleton<LoggingUtil>.Instance.LogWarning("Could not get a job assignment for bot " + bot.GetText());
-            }
-
             return null;
         }
 
-        public static bool DoesBotHaveNewJobAssignment(this BotOwner bot)
+        public static void Register(this BotJobAssignment assignment)
         {
-            if (!botJobAssignments.ContainsKey(bot.Profile.Id))
-            {
-                botJobAssignments.Add(bot.Profile.Id, new List<BotJobAssignment>());
-            }
-
-            if (botJobAssignments[bot.Profile.Id].Count > 0)
-            {
-                BotJobAssignment currentAssignment = botJobAssignments[bot.Profile.Id].Last();
-
-                // Check if the bot is currently doing an assignment
-                if (currentAssignment.IsActive)
-                {
-                    return false;
-                }
-
-                // Check if more steps are available for the bot's current assignment
-                if (currentAssignment.TrySetNextObjectiveStep(false))
-                {
-                    return true;
-                }
-
-                //Singleton<LoggingUtil>.Instance.LogInfo("There are no more steps available for " + bot.GetText() + " in " + (currentAssignment.QuestObjectiveAssignment?.ToString() ?? "???"));
-            }
-
-            if (bot.GetNewBotJobAssignment() != null)
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        [Benchmark]
-        public static BotJobAssignment GetNewBotJobAssignment(this BotOwner bot)
-        {
-            if (bot == null)
-            {
-                throw new ArgumentNullException("Cannot get an assignment for a null bot");
-            }
-
-            // Do not select another quest objective if the bot wants to extract
-            BotObjectiveManager? botObjectiveManager = bot.GetObjectiveManager();
-            if ((botObjectiveManager != null) && botObjectiveManager.DoesBotWantToExtract())
-            {
-                return null!;
-            }
-
-            float maxDistanceBetweenExfils = Singleton<GameWorld>.Instance.GetComponent<Components.LocationData>().GetMaxDistanceBetweenExfils();
-            float minDistanceToSwitchExfil = maxDistanceBetweenExfils * Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilReachedMinFraction;
-
-            // If the bot is close to its selected exfil (only used for quest selection), select a new one
-            float? distanceToExfilPoint = botObjectiveManager?.DistanceToExfiltrationPointForQuesting();
-            if (distanceToExfilPoint.HasValue && (distanceToExfilPoint.Value < minDistanceToSwitchExfil))
-            {
-                botObjectiveManager?.SetExfiliationPointForQuesting();
-            }
-
-            // Get the bot's most recent assingment if applicable
-            BotQuest? quest = null;
-            BotQuestObjective? objective = null;
-            if (botJobAssignments[bot.Profile.Id].Count > 0)
-            {
-                quest = botJobAssignments[bot.Profile.Id].Last().QuestAssignment;
-                objective = botJobAssignments[bot.Profile.Id].Last().QuestObjectiveAssignment;
-            }
-
-            // Clear the bot's assignment if it's been doing the same quest for too long
-            if ((quest?.HasBotBeingDoingQuestTooLong(bot, out double? timeDoingQuest) == true) && (timeDoingQuest != null))
-            {
-                Singleton<LoggingUtil>.Instance.LogInfo(bot.GetText() + " has been performing quest " + quest.ToString() + " for " + timeDoingQuest.Value + "s and will get a new one.");
-                quest = null;
-                objective = null;
-            }
-
-            // Try to find a quest that has at least one objective that can be assigned to the bot
-            List<BotQuest> invalidQuests = new List<BotQuest>();
-            Stopwatch timeoutMonitor = Stopwatch.StartNew();
-            do
-            {
-                // Find the nearest objective for the bot's currently assigned quest (if any)
-                objective = quest?
-                    .RemainingObjectivesForBot(bot)?
-                    .Where(o => o.CanAssignBot(bot))?
-                    .Where(o => o.CanBotRepeatQuestObjective(bot))?
-                    .NearestToBot(bot);
-
-                // Exit the loop if an objective was found for the bot
-                if (objective != null)
-                {
-                    break;
-                }
-                if (quest != null)
-                {
-                    //Singleton<LoggingUtil>.Instance.LogInfo(bot.GetText() + " cannot select quest " + quest.ToString() + " because it has no valid objectives");
-                    invalidQuests.Add(quest);
-                }
-
-                // If no objectives were found, select another quest
-                quest = bot.GetRandomQuest(invalidQuests);
-
-                // If a quest hasn't been found within a certain amount of time, something is wrong
-                if (timeoutMonitor.ElapsedMilliseconds > Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.QuestSelectionTimeout)
-                {
-                    // First try allowing the bot to repeat quests it already completed
-                    if (bot.TryArchiveRepeatableAssignments() > 0)
-                    {
-                        Singleton<LoggingUtil>.Instance.LogWarning(bot.GetText() + " cannot select any quests. Trying to select a repeatable quest early instead...");
-                        continue;
-                    }
-
-                    // If there are still no quests available for the bot to select, give up trying to select one
-                    Singleton<LoggingUtil>.Instance.LogError(bot.GetText() + " could not select any of the following quests: " + string.Join(", ", bot.GetAllPossibleQuests()));
-                    botObjectiveManager?.StopQuesting();
-
-                    // Try making the bot extract because it has nothing to do
-                    if (botObjectiveManager?.BotMonitor?.GetMonitor<BotExtractMonitor>()?.TryInstructBotToExtract() == true)
-                    {
-                        Singleton<LoggingUtil>.Instance.LogWarning(bot.GetText() + " cannot select any quests. Extracting instead...");
-                        return null!;
-                    }
-
-                    Singleton<LoggingUtil>.Instance.LogError(bot.GetText() + " cannot select any quests. Questing disabled.");
-                    return null!;
-                }
-
-            } while (objective == null);
-
-            if (quest == null)
-            {
-                return null!;
-            }
-
-            // Once a valid assignment is selected, assign it to the bot
-            BotJobAssignment assignment = new BotJobAssignment(bot, quest, objective);
-            RegisterBotJobAssignment(assignment);
-
-            return assignment;
-        }
-
-        public static void RegisterBotJobAssignment(BotJobAssignment assignment)
-        {
-            string botId = assignment.BotOwner.Profile.Id;
-
-            if (!botJobAssignments.ContainsKey(botId))
-            {
-                botJobAssignments.Add(botId, new List<BotJobAssignment>());
-            }
-
-            botJobAssignments[botId].Add(assignment);
-        }
-
-        public static IEnumerable<BotQuest> GetAllPossibleQuests(this BotOwner bot)
-        {
-            int botGroupSize = BotLogic.HiveMind.BotHiveMindMonitor.GetFollowers(bot).Count + 1;
-
-            return allQuests
-                .Where(q => q.Desirability != 0)
-                .Where(q => q.NumberOfValidObjectives > 0)
-                .Where(q => q.MaxBotsInGroup >= botGroupSize)
-                .Where(q => q.CanMoreBotsDoQuest())
-                .Where(q => q.CanAssignToBot(bot))
-                .ToArray();
-        }
-
-        public static BotQuest GetRandomQuest(this BotOwner bot, IEnumerable<BotQuest> invalidQuests)
-        {
-            if (bot == null)
-            {
-                throw new ArgumentNullException("Cannot get a quest for a null bot");
-            }
-
-            Stopwatch questSelectionTimer = Stopwatch.StartNew();
-
-            BotQuest[] assignableQuests = bot.GetAllPossibleQuests()
-                .Where(q => !invalidQuests.Contains(q))
-                .ToArray();
-
-            if (!assignableQuests.Any())
-            {
-                return null!;
-            }
-
-            BotObjectiveManager? botObjectiveManager = bot?.GetObjectiveManager();
-            Vector3? vectorToExfil = botObjectiveManager?.VectorToExfiltrationPointForQuesting();
-
-            Dictionary<BotQuest, Configuration.MinMaxConfig> questDistanceRanges = new Dictionary<BotQuest, Configuration.MinMaxConfig>();
-            Dictionary<BotQuest, Configuration.MinMaxConfig> questExfilAngleRanges = new Dictionary<BotQuest, Configuration.MinMaxConfig>();
-
-            // Calculate the distances from the bot to all valid quest objectives and the angles between the vector to the bot's selected
-            // exfil (for questing) and the vector to each valid quest objective
-            foreach (BotQuest quest in assignableQuests)
-            {
-                IEnumerable<Vector3?> objectivePositions = quest.ValidObjectives.Select(o => o.GetFirstStepPosition());
-                IEnumerable<Vector3> validObjectivePositions = objectivePositions.Where(p => p.HasValue).Select(p => p!.Value);
-                IEnumerable<float> distancesToObjectives = validObjectivePositions.Select(p => Vector3.Distance(bot!.Position, p));
-
-                questDistanceRanges.Add(quest, new Configuration.MinMaxConfig(distancesToObjectives.Min(), distancesToObjectives.Max()));
-
-                if (vectorToExfil.HasValue)
-                {
-                    IEnumerable<Vector3> vectorsToObjectivePositions = validObjectivePositions.Select(p => p - bot!.Position);
-                    IEnumerable<float> anglesToObjectives = vectorsToObjectivePositions.Select(p => Vector3.Angle(p - bot!.Position, vectorToExfil.Value));
-
-                    questExfilAngleRanges.Add(quest, new Configuration.MinMaxConfig(anglesToObjectives.Min(), anglesToObjectives.Max()));
-                }
-                else
-                {
-                    questExfilAngleRanges.Add(quest, new Configuration.MinMaxConfig(0, 0));
-                }
-            }
-
-            // Calculate the maximum amount of "randomness" to apply to each quest
-            //double distanceRange = questDistanceRanges.Max(q => q.Value.Max) - questDistanceRanges.Min(q => q.Value.Min);
-            double maxDistance = questDistanceRanges.Max(o => o.Value.Max);
-            int maxRandomDistance = (int)Math.Ceiling(maxDistance * Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DistanceRandomness / 100.0);
-            float maxExfilAngle = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionMaxAngle;
-
-            int distanceRandomness = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DistanceRandomness;
-            int desirabilityRandomness = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DesirabilityRandomness;
-
-            float distanceWeighting = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DistanceWeighting;
-            float desirabilityWeighting = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DesirabilityWeighting;
-            float exfilDirectionWeighting = 0;
-
-            string locationId = Singleton<GameWorld>.Instance.GetComponent<Components.LocationData>().CurrentLocation.Id;
-            if (Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionWeighting.ContainsKey(locationId))
-            {
-                exfilDirectionWeighting = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionWeighting[locationId];
-            }
-            else if (Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionWeighting.ContainsKey("default"))
-            {
-                exfilDirectionWeighting = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionWeighting["default"];
-            }
-
-            System.Random random = new System.Random();
-            Dictionary<BotQuest, double> questDistanceFractions = questDistanceRanges
-                .ToDictionary(o => o.Key, o => 1 - (o.Value.Min + random.Next(-1 * maxRandomDistance, maxRandomDistance)) / maxDistance);
-            Dictionary<BotQuest, float> questDesirabilityFractions = questDistanceRanges
-                .ToDictionary(o => o.Key, o => 
-                (
-                    o.Key.Desirability * (o.Key.IsActiveForPlayer ? Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DesirabilityActiveQuestMultiplier : 1)
-                    + random.Next(-1 * desirabilityRandomness, desirabilityRandomness)) / 100
-                );
-            Dictionary<BotQuest, double> questExfilAngleFactor = questExfilAngleRanges
-                .ToDictionary(o => o.Key, o => Math.Max(0, o.Value.Min - maxExfilAngle) / (180 - maxExfilAngle));
-
-            IEnumerable<BotQuest> sortedQuests = questDistanceRanges
-                .OrderBy
-                (o =>
-                    (questDistanceFractions[o.Key] * distanceWeighting)
-                    + (questDesirabilityFractions[o.Key] * desirabilityWeighting)
-                    - (questExfilAngleFactor[o.Key] * exfilDirectionWeighting)
-                )
-                .Select(o => o.Key);
-
-            BotQuest selectedQuest = sortedQuests.Last();
-
-            //Singleton<LoggingUtil>.Instance.LogInfo("Distance: " + questDistanceFractions[selectedQuest] + ", Desirability: " + questDesirabilityFractions[selectedQuest] + ", Exfil Angle Factor: " + questExfilAngleFactor[selectedQuest]);
-            //Singleton<LoggingUtil>.Instance.LogInfo("Time for quest selection: " + questSelectionTimer.ElapsedMilliseconds + "ms");
-
-            return selectedQuest;
+            assignment.BotOwner.InitializeBotJobAssignmentsList();
+            botJobAssignments[assignment.BotOwner.Profile.Id].Add(assignment);
         }
 
         public static IEnumerable<BotJobAssignment> GetAllQuests(this BotOwner bot)
@@ -949,7 +692,14 @@ namespace QuestingBots.Controllers
 
         public static void CheckBotJobAssignmentValidity(BotOwner bot)
         {
-            BotJobAssignment? botJobAssignment = GetCurrentJobAssignment(bot, false);
+            BotObjectiveManager? botObjectiveManager = bot.GetObjectiveManager();
+            if (botObjectiveManager == null)
+            {
+                Singleton<LoggingUtil>.Instance.LogError($"Cannot retrieve the objective manager for {bot.GetText()}");
+                return;
+            }
+
+            BotJobAssignment? botJobAssignment = botObjectiveManager.QuestSelector.GetCurrentJobAssignment(false);
             if (botJobAssignment?.QuestAssignment == null)
             {
                 return;
@@ -958,13 +708,6 @@ namespace QuestingBots.Controllers
             int botGroupSize = BotLogic.HiveMind.BotHiveMindMonitor.GetFollowers(bot).Count + 1;
             if (botGroupSize > botJobAssignment.QuestAssignment.MaxBotsInGroup)
             {
-                BotObjectiveManager? botObjectiveManager = bot.GetObjectiveManager();
-                if (botObjectiveManager == null)
-                {
-                    Singleton<LoggingUtil>.Instance.LogError($"Cannot retrieve the objective manager for {bot.GetText()}");
-                    return;
-                }
-
                 if (botObjectiveManager.TryChangeObjective())
                 {
                     Singleton<LoggingUtil>.Instance.LogWarning("Selected new quest for " + bot.GetText() + " because it has too many followers for its previous quest");

--- a/Client/Controllers/BotJobAssignmentFactory.cs
+++ b/Client/Controllers/BotJobAssignmentFactory.cs
@@ -698,7 +698,7 @@ namespace QuestingBots.Controllers
                 return;
             }
 
-            BotJobAssignment? botJobAssignment = botObjectiveManager.QuestSelector.GetCurrentJobAssignment(false);
+            BotJobAssignment? botJobAssignment = botObjectiveManager.QuestSelector.GetCurrentJobAssignment();
             if (botJobAssignment?.QuestAssignment == null)
             {
                 return;

--- a/Client/Controllers/BotJobAssignmentFactory.cs
+++ b/Client/Controllers/BotJobAssignmentFactory.cs
@@ -21,13 +21,13 @@ namespace QuestingBots.Controllers
     public static class BotJobAssignmentFactory
     {
         private static CoroutineExtensions.EnumeratorWithTimeLimit enumeratorWithTimeLimit = new CoroutineExtensions.EnumeratorWithTimeLimit(Singleton<ConfigUtil>.Instance.CurrentConfig.MaxCalcTimePerFrame);
-        private static List<Quest> allQuests = new List<Quest>();
+        private static List<BotQuest> allQuests = new List<BotQuest>();
         private static Dictionary<string, List<BotJobAssignment>> botJobAssignments = new Dictionary<string, List<BotJobAssignment>>();
 
         public static int QuestCount => allQuests.Count;
 
-        public static Quest[] FindQuestsWithZone(string zoneId) => allQuests.Where(q => q.GetObjectiveForZoneID(zoneId) != null).ToArray();
-        public static bool CanMoreBotsDoQuest(this Quest quest) => quest.NumberOfActiveBots() < quest.MaxBots;
+        public static BotQuest[] FindQuestsWithZone(string zoneId) => allQuests.Where(q => q.GetObjectiveForZoneID(zoneId) != null).ToArray();
+        public static bool CanMoreBotsDoQuest(this BotQuest quest) => quest.NumberOfActiveBots() < quest.MaxBots;
 
         public static void Clear()
         {
@@ -35,7 +35,7 @@ namespace QuestingBots.Controllers
             allQuests.RemoveAll(q => q.Template == null);
 
             // Remove all objectives for remaining quests. New objectives will be generated after loading the map.
-            foreach (Quest quest in allQuests)
+            foreach (BotQuest quest in allQuests)
             {
                 quest.Clear();
             }
@@ -43,27 +43,27 @@ namespace QuestingBots.Controllers
             botJobAssignments.Clear();
         }
 
-        public static IEnumerator ProcessAllQuests(Action<Quest> action)
+        public static IEnumerator ProcessAllQuests(Action<BotQuest> action)
         {
             enumeratorWithTimeLimit.Reset();
             yield return enumeratorWithTimeLimit.Run(allQuests, action);
         }
 
-        public static IEnumerator ProcessAllQuests<T1>(Action<Quest, T1> action, T1 param1)
+        public static IEnumerator ProcessAllQuests<T1>(Action<BotQuest, T1> action, T1 param1)
         {
             enumeratorWithTimeLimit.Reset();
             yield return enumeratorWithTimeLimit.Run(allQuests, action, param1);
         }
 
-        public static IEnumerator ProcessAllQuests<T1, T2>(Action<Quest, T1, T2> action, T1 param1, T2 param2)
+        public static IEnumerator ProcessAllQuests<T1, T2>(Action<BotQuest, T1, T2> action, T1 param1, T2 param2)
         {
             enumeratorWithTimeLimit.Reset();
             yield return enumeratorWithTimeLimit.Run(allQuests, action, param1, param2);
         }
 
-        public static void AddQuest(Quest quest)
+        public static void AddQuest(BotQuest quest)
         {
-            foreach(QuestObjective objective in quest.AllObjectives)
+            foreach(BotQuestObjective objective in quest.AllObjectives)
             {
                 objective.UpdateQuestObjectiveStepNumbers();
             }
@@ -89,9 +89,9 @@ namespace QuestingBots.Controllers
             allQuests.Add(quest);
         }
 
-        public static Quest FindQuest(string questID)
+        public static BotQuest FindQuest(string questID)
         {
-            IEnumerable<Quest> matchingQuests = allQuests.Where(q => q.Template?.Id == questID);
+            IEnumerable<BotQuest> matchingQuests = allQuests.Where(q => q.Template?.Id == questID);
             if (matchingQuests.Count() == 1)
             {
                 return matchingQuests.First();
@@ -102,9 +102,9 @@ namespace QuestingBots.Controllers
 
         public static void RemoveBlacklistedQuestObjectives(string locationId)
         {
-            foreach (Quest quest in allQuests.ToArray())
+            foreach (BotQuest quest in allQuests.ToArray())
             {
-                foreach (QuestObjective objective in quest.AllObjectives)
+                foreach (BotQuestObjective objective in quest.AllObjectives)
                 {
                     // Check if Lightkeeper Island quests should be blacklisted
                     if (locationId == "Lighthouse")
@@ -197,7 +197,7 @@ namespace QuestingBots.Controllers
             return matchingAssignments.Count();
         }
 
-        public static int NumberOfActiveBots(this Quest quest)
+        public static int NumberOfActiveBots(this BotQuest quest)
         {
             float pendingTimeLimit = 0.3f;
 
@@ -216,7 +216,7 @@ namespace QuestingBots.Controllers
             return num;
         }
 
-        public static IEnumerable<QuestObjective> RemainingObjectivesForBot(this Quest quest, BotOwner bot)
+        public static IEnumerable<BotQuestObjective> RemainingObjectivesForBot(this BotQuest quest, BotOwner bot)
         {
             if (bot == null)
             {
@@ -240,10 +240,10 @@ namespace QuestingBots.Controllers
             return quest.AllObjectives.Where(o => !matchingAssignments.Any(a => a.QuestObjectiveAssignment == o));
         }
 
-        public static QuestObjective NearestToBot(this IEnumerable<QuestObjective> objectives, BotOwner bot)
+        public static BotQuestObjective NearestToBot(this IEnumerable<BotQuestObjective> objectives, BotOwner bot)
         {
-            Dictionary<QuestObjective, float> objectiveDistances = new Dictionary<QuestObjective, float>();
-            foreach (QuestObjective objective in objectives)
+            Dictionary<BotQuestObjective, float> objectiveDistances = new Dictionary<BotQuestObjective, float>();
+            foreach (BotQuestObjective objective in objectives)
             {
                 Vector3? firstStepPosition = objective.GetFirstStepPosition();
                 if (!firstStepPosition.HasValue)
@@ -262,7 +262,7 @@ namespace QuestingBots.Controllers
             return objectiveDistances.OrderBy(i => i.Value).First().Key;
         }
 
-        public static DateTime? TimeWhenLastEndedForBot(this Quest quest, BotOwner bot)
+        public static DateTime? TimeWhenLastEndedForBot(this BotQuest quest, BotOwner bot)
         {
             if (!botJobAssignments.ContainsKey(bot.Profile.Id))
             {
@@ -284,7 +284,7 @@ namespace QuestingBots.Controllers
             return matchingAssignments.First().EndTime;
         }
 
-        public static double? ElapsedTimeWhenLastEndedForBot(this Quest quest, BotOwner bot)
+        public static double? ElapsedTimeWhenLastEndedForBot(this BotQuest quest, BotOwner bot)
         {
             DateTime? lastObjectiveEndingTime = quest.TimeWhenLastEndedForBot(bot);
             if (!lastObjectiveEndingTime.HasValue)
@@ -295,7 +295,7 @@ namespace QuestingBots.Controllers
             return (DateTime.Now - lastObjectiveEndingTime.Value).TotalSeconds;
         }
 
-        public static DateTime? TimeWhenBotStarted(this Quest quest, BotOwner bot)
+        public static DateTime? TimeWhenBotStarted(this BotQuest quest, BotOwner bot)
         {
             if (!botJobAssignments.ContainsKey(bot.Profile.Id))
             {
@@ -315,7 +315,7 @@ namespace QuestingBots.Controllers
             return matchingAssignments.Last().EndTime;
         }
 
-        public static double? ElapsedTimeSinceBotStarted(this Quest quest, BotOwner bot)
+        public static double? ElapsedTimeSinceBotStarted(this BotQuest quest, BotOwner bot)
         {
             DateTime? firstObjectiveEndingTime = quest.TimeWhenBotStarted(bot);
             if (!firstObjectiveEndingTime.HasValue)
@@ -326,7 +326,7 @@ namespace QuestingBots.Controllers
             return (DateTime.Now - firstObjectiveEndingTime.Value).TotalSeconds;
         }
 
-        public static bool CanAssignToBot(this Quest quest, BotOwner bot)
+        public static bool CanAssignToBot(this BotQuest quest, BotOwner bot)
         {
             if (bot == null)
             {
@@ -379,7 +379,7 @@ namespace QuestingBots.Controllers
             return false;
         }
 
-        public static bool TryArchiveIfBotCanRepeat(this Quest quest, BotOwner bot)
+        public static bool TryArchiveIfBotCanRepeat(this BotQuest quest, BotOwner bot)
         {
             if (!quest.IsRepeatable)
             {
@@ -417,7 +417,7 @@ namespace QuestingBots.Controllers
             return matchingAssignments.Length;
         }
 
-        public static bool CanBotRepeatQuestObjective(this QuestObjective objective, BotOwner bot)
+        public static bool CanBotRepeatQuestObjective(this BotQuestObjective objective, BotOwner bot)
         {
             IEnumerable<BotJobAssignment> matchingAssignments = botJobAssignments[bot.Profile.Id]
                 .Where(a => a.QuestObjectiveAssignment == objective);
@@ -436,7 +436,7 @@ namespace QuestingBots.Controllers
             return objective.IsRepeatable && matchingAssignments.All(a => a.Status == JobAssignmentStatus.Archived);
         }
 
-        public static bool HasBotBeingDoingQuestTooLong(this Quest quest, BotOwner bot, out double? time)
+        public static bool HasBotBeingDoingQuestTooLong(this BotQuest quest, BotOwner bot, out double? time)
         {
             time = quest.ElapsedTimeSinceBotStarted(bot);
             if (time.HasValue && (time >= Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuestingRequirements.MaxTimePerQuest))
@@ -544,8 +544,8 @@ namespace QuestingBots.Controllers
             }
 
             // Get the bot's most recent assingment if applicable
-            Quest? quest = null;
-            QuestObjective? objective = null;
+            BotQuest? quest = null;
+            BotQuestObjective? objective = null;
             if (botJobAssignments[bot.Profile.Id].Count > 0)
             {
                 quest = botJobAssignments[bot.Profile.Id].Last().QuestAssignment;
@@ -561,7 +561,7 @@ namespace QuestingBots.Controllers
             }
 
             // Try to find a quest that has at least one objective that can be assigned to the bot
-            List<Quest> invalidQuests = new List<Quest>();
+            List<BotQuest> invalidQuests = new List<BotQuest>();
             Stopwatch timeoutMonitor = Stopwatch.StartNew();
             do
             {
@@ -637,7 +637,7 @@ namespace QuestingBots.Controllers
             botJobAssignments[botId].Add(assignment);
         }
 
-        public static IEnumerable<Quest> GetAllPossibleQuests(this BotOwner bot)
+        public static IEnumerable<BotQuest> GetAllPossibleQuests(this BotOwner bot)
         {
             int botGroupSize = BotLogic.HiveMind.BotHiveMindMonitor.GetFollowers(bot).Count + 1;
 
@@ -650,7 +650,7 @@ namespace QuestingBots.Controllers
                 .ToArray();
         }
 
-        public static Quest GetRandomQuest(this BotOwner bot, IEnumerable<Quest> invalidQuests)
+        public static BotQuest GetRandomQuest(this BotOwner bot, IEnumerable<BotQuest> invalidQuests)
         {
             if (bot == null)
             {
@@ -659,7 +659,7 @@ namespace QuestingBots.Controllers
 
             Stopwatch questSelectionTimer = Stopwatch.StartNew();
 
-            Quest[] assignableQuests = bot.GetAllPossibleQuests()
+            BotQuest[] assignableQuests = bot.GetAllPossibleQuests()
                 .Where(q => !invalidQuests.Contains(q))
                 .ToArray();
 
@@ -671,12 +671,12 @@ namespace QuestingBots.Controllers
             BotObjectiveManager? botObjectiveManager = bot?.GetObjectiveManager();
             Vector3? vectorToExfil = botObjectiveManager?.VectorToExfiltrationPointForQuesting();
 
-            Dictionary<Quest, Configuration.MinMaxConfig> questDistanceRanges = new Dictionary<Quest, Configuration.MinMaxConfig>();
-            Dictionary<Quest, Configuration.MinMaxConfig> questExfilAngleRanges = new Dictionary<Quest, Configuration.MinMaxConfig>();
+            Dictionary<BotQuest, Configuration.MinMaxConfig> questDistanceRanges = new Dictionary<BotQuest, Configuration.MinMaxConfig>();
+            Dictionary<BotQuest, Configuration.MinMaxConfig> questExfilAngleRanges = new Dictionary<BotQuest, Configuration.MinMaxConfig>();
 
             // Calculate the distances from the bot to all valid quest objectives and the angles between the vector to the bot's selected
             // exfil (for questing) and the vector to each valid quest objective
-            foreach (Quest quest in assignableQuests)
+            foreach (BotQuest quest in assignableQuests)
             {
                 IEnumerable<Vector3?> objectivePositions = quest.ValidObjectives.Select(o => o.GetFirstStepPosition());
                 IEnumerable<Vector3> validObjectivePositions = objectivePositions.Where(p => p.HasValue).Select(p => p!.Value);
@@ -721,18 +721,18 @@ namespace QuestingBots.Controllers
             }
 
             System.Random random = new System.Random();
-            Dictionary<Quest, double> questDistanceFractions = questDistanceRanges
+            Dictionary<BotQuest, double> questDistanceFractions = questDistanceRanges
                 .ToDictionary(o => o.Key, o => 1 - (o.Value.Min + random.Next(-1 * maxRandomDistance, maxRandomDistance)) / maxDistance);
-            Dictionary<Quest, float> questDesirabilityFractions = questDistanceRanges
+            Dictionary<BotQuest, float> questDesirabilityFractions = questDistanceRanges
                 .ToDictionary(o => o.Key, o => 
                 (
                     o.Key.Desirability * (o.Key.IsActiveForPlayer ? Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DesirabilityActiveQuestMultiplier : 1)
                     + random.Next(-1 * desirabilityRandomness, desirabilityRandomness)) / 100
                 );
-            Dictionary<Quest, double> questExfilAngleFactor = questExfilAngleRanges
+            Dictionary<BotQuest, double> questExfilAngleFactor = questExfilAngleRanges
                 .ToDictionary(o => o.Key, o => Math.Max(0, o.Value.Min - maxExfilAngle) / (180 - maxExfilAngle));
 
-            IEnumerable<Quest> sortedQuests = questDistanceRanges
+            IEnumerable<BotQuest> sortedQuests = questDistanceRanges
                 .OrderBy
                 (o =>
                     (questDistanceFractions[o.Key] * distanceWeighting)
@@ -741,7 +741,7 @@ namespace QuestingBots.Controllers
                 )
                 .Select(o => o.Key);
 
-            Quest selectedQuest = sortedQuests.Last();
+            BotQuest selectedQuest = sortedQuests.Last();
 
             //Singleton<LoggingUtil>.Instance.LogInfo("Distance: " + questDistanceFractions[selectedQuest] + ", Desirability: " + questDesirabilityFractions[selectedQuest] + ", Exfil Angle Factor: " + questExfilAngleFactor[selectedQuest]);
             //Singleton<LoggingUtil>.Instance.LogInfo("Time for quest selection: " + questSelectionTimer.ElapsedMilliseconds + "ms");
@@ -803,9 +803,9 @@ namespace QuestingBots.Controllers
             sb.AppendLine("Quest Name,Objective,Steps,Min Level,Max Level,First Step Position");
 
             // Write a row for every objective in every quest
-            foreach (Quest quest in allQuests)
+            foreach (BotQuest quest in allQuests)
             {
-                foreach (QuestObjective objective in quest.AllObjectives)
+                foreach (BotQuestObjective objective in quest.AllObjectives)
                 {
                     Vector3? firstPosition = objective.GetFirstStepPosition();
                     if (!firstPosition.HasValue)
@@ -899,11 +899,11 @@ namespace QuestingBots.Controllers
         {
             List<JobAssignment> allAssignments = new List<JobAssignment>();
 
-            foreach (Quest quest in allQuests)
+            foreach (BotQuest quest in allQuests)
             {
-                foreach (QuestObjective objective in quest.ValidObjectives)
+                foreach (BotQuestObjective objective in quest.ValidObjectives)
                 {
-                    foreach (QuestObjectiveStep step in objective.AllSteps)
+                    foreach (BotQuestObjectiveStep step in objective.AllSteps)
                     {
                         JobAssignment assignment = new JobAssignment(quest, objective, step);
                         allAssignments.Add(assignment);
@@ -914,18 +914,18 @@ namespace QuestingBots.Controllers
             return allAssignments;
         }
 
-        public static IEnumerable<QuestObjective> GetQuestObjectivesNearPosition(Vector3 position, float distance, bool allowEFTQuests = true)
+        public static IEnumerable<BotQuestObjective> GetQuestObjectivesNearPosition(Vector3 position, float distance, bool allowEFTQuests = true)
         {
-            List<QuestObjective> nearbyObjectives = new List<QuestObjective>();
+            List<BotQuestObjective> nearbyObjectives = new List<BotQuestObjective>();
 
-            foreach (Quest quest in allQuests)
+            foreach (BotQuest quest in allQuests)
             {
                 if (!allowEFTQuests && quest.IsEFTQuest)
                 {
                     continue;
                 }
 
-                foreach (QuestObjective objective in quest.ValidObjectives)
+                foreach (BotQuestObjective objective in quest.ValidObjectives)
                 {
                     Vector3? firstStepPosition = objective.GetFirstStepPosition();
                     if (!firstStepPosition.HasValue)

--- a/Client/Controllers/BotJobAssignmentFactory.cs
+++ b/Client/Controllers/BotJobAssignmentFactory.cs
@@ -3,6 +3,7 @@ using Diz.Utils;
 using EFT;
 using QuestingBots.BotLogic.BotMonitor.Monitors;
 using QuestingBots.Components;
+using QuestingBots.Components.Spawning;
 using QuestingBots.Helpers;
 using QuestingBots.Models.Questing;
 using QuestingBots.Utils;
@@ -870,7 +871,7 @@ namespace QuestingBots.Controllers
                 }
             }
 
-            foreach (Profile profile in Components.Spawning.BotGenerator.GetAllGeneratedBotProfiles())
+            foreach (Profile profile in Singleton<GameWorld>.Instance.GetComponent<BotGenerationManager>().GetAllGeneratedBotProfiles())
             {
                 if (botJobAssignments.ContainsKey(profile.Id))
                 {

--- a/Client/Controllers/BotJobAssignmentFactory.cs
+++ b/Client/Controllers/BotJobAssignmentFactory.cs
@@ -15,7 +15,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using UnityEngine;
-using static Assets.CommonAssets.Scripts.Utilities.ColliderExtendedDebug;
 
 namespace QuestingBots.Controllers
 {

--- a/Client/Controllers/BotRegistrationManager.cs
+++ b/Client/Controllers/BotRegistrationManager.cs
@@ -1,6 +1,7 @@
 ﻿using Comfort.Common;
 using EFT;
 using QuestingBots.BotLogic.BotMonitor;
+using QuestingBots.Components.Spawning;
 using QuestingBots.Configuration;
 using QuestingBots.Helpers;
 using QuestingBots.Utils;
@@ -107,14 +108,13 @@ namespace QuestingBots.Controllers
             return null;
         }
 
-        [Benchmark]
         public static void WriteMessageForNewBotSpawn(BotOwner botOwner)
         {
             SpawnedBotCount++;
             string message = "Spawned ";
 
             // If initial PMC's need to spawn but haven't yet, assume the bot is a boss. Otherwise, PMC's should have already spawned. 
-            Singleton<GameWorld>.Instance.TryGetComponent(out Components.Spawning.PMCGenerator pmcGenerator);
+            BotGenerator? pmcGenerator = Singleton<GameWorld>.Instance.GetComponent<BotGenerationManager>().GetActiveBotGenerator<PMCGenerator>();
             if ((pmcGenerator != null) && pmcGenerator.HasGeneratedBots && !pmcGenerator.IsSpawningBots && (pmcGenerator.SpawnedGroupCount == 0))
             {
                 message += "boss " + botOwner.GetText() + " (" + registeredBosses.Count + "/" + ZeroWaveTotalBotCount + ")";
@@ -200,7 +200,6 @@ namespace QuestingBots.Controllers
             }
         }
 
-        [Benchmark]
         private static void updateAllHostileGroupEnemies()
         {
             foreach (BotsGroup hostileGroup in hostileGroups)
@@ -242,7 +241,6 @@ namespace QuestingBots.Controllers
 
         private static IEnumerable<BotOwner> getAliveGroupMembers(BotsGroup group)
         {
-            List<BotOwner> groupMemberList = new List<BotOwner>();
             for (int m = 0; m < group.MembersCount; m++)
             {
                 BotOwner member = group.Member(m);
@@ -252,10 +250,8 @@ namespace QuestingBots.Controllers
                     continue;
                 }
 
-                groupMemberList.Add(member);
+                yield return member;
             }
-
-            return groupMemberList;
         }
     }
 }

--- a/Client/Helpers/BotBrainHelpers.cs
+++ b/Client/Helpers/BotBrainHelpers.cs
@@ -383,7 +383,7 @@ namespace QuestingBots.Helpers
 
         public static bool ShouldPlayerBeTreatedAsHuman(this IPlayer player)
         {
-            return !player.IsAI || BotGenerator.GetAllGeneratedBotProfileIDs().Contains(player.Profile.Id);
+            return !player.IsAI || Singleton<GameWorld>.Instance.GetComponent<BotGenerationManager>().GetAllGeneratedBotProfileIDs().Contains(player.Profile.Id);
         }
 
         public static bool ShouldPlayerBeTreatedAsHuman(this BotOwner bot)

--- a/Client/Helpers/BotBrainHelpers.cs
+++ b/Client/Helpers/BotBrainHelpers.cs
@@ -323,13 +323,7 @@ namespace QuestingBots.Helpers
         };
 
         public static bool WillBeAPMC(this BotOwner bot) => bot.Profile.WillBeAPMC();
-
-        public static bool WillBeAPMC(this Profile profile)
-        {
-            return Enumerable.Empty<BotBrainType>()
-                .AddPMCBrains()
-                .Any(b => b.SpawnType == profile.Info.Settings.Role);
-        }
+        public static bool WillBeAPMC(this Profile profile) => PMCSpawnTypes.Contains(profile.Info.Settings.Role);
 
         public static bool WillBeABoss(this BotOwner botOwner)
         {

--- a/Client/Helpers/BotBrainHelpers.cs
+++ b/Client/Helpers/BotBrainHelpers.cs
@@ -2,6 +2,7 @@
 using DrakiaXYZ.BigBrain.Brains;
 using EFT;
 using QuestingBots.Components.Spawning;
+using QuestingBots.Controllers;
 using QuestingBots.Models;
 using QuestingBots.Utils;
 using System;
@@ -33,6 +34,28 @@ namespace QuestingBots.Helpers
             Singleton<LoggingUtil>.Instance.LogDebug("Loading QuestingBots...changing bot brains for following: " + string.Join(", ", allNonSniperBrains));
             BrainManager.AddCustomLayer(typeof(BotLogic.Follow.BotFollowerLayer), allNonSniperBrains.ToStringList(), brainLayerPriorities.Following);
             BrainManager.AddCustomLayer(typeof(BotLogic.Follow.BotFollowerRegroupLayer), allNonSniperBrains.ToStringList(), brainLayerPriorities.Regrouping);
+        }
+
+        public static bool AllowsQuesting(this BotType botType)
+        {
+            if ((botType == BotType.PMC) && Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.AllowedBotTypesForQuesting.PMC)
+            {
+                return true;
+            }
+            if ((botType == BotType.Boss) && Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.AllowedBotTypesForQuesting.Boss)
+            {
+                return true;
+            }
+            if ((botType == BotType.Scav) && Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.AllowedBotTypesForQuesting.Scav)
+            {
+                return true;
+            }
+            if ((botType == BotType.PScav) && Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.AllowedBotTypesForQuesting.PScav)
+            {
+                return true;
+            }
+
+            return false;
         }
 
         public static IEnumerable<BotBrainType> AddTestBrains(this IEnumerable<BotBrainType> list)

--- a/Client/Helpers/ItemHelpers.cs
+++ b/Client/Helpers/ItemHelpers.cs
@@ -33,17 +33,14 @@ namespace QuestingBots.Helpers
 
     public static class ItemHelpers
     {
-        public static InventoryController GetInventoryController(this BotOwner bot)
-        {
-            Type playerType = typeof(Player);
-
-            FieldInfo inventoryControllerField = playerType.GetField("_inventoryController", BindingFlags.NonPublic | BindingFlags.Instance);
-            return (InventoryController)inventoryControllerField.GetValue(bot.GetPlayer);
-        }
+        public static InventoryController GetInventoryController(this BotOwner bot) => bot.GetPlayer.InventoryController;
 
         public static IEnumerable<WeaponClass> ToWeaponClasses(this IEnumerable<string> weaponClassNames)
         {
-            return weaponClassNames.Select(n => (WeaponClass)Enum.Parse(typeof(WeaponClass), n));
+            foreach (string weaponClassName in weaponClassNames)
+            {
+                yield return (WeaponClass)Enum.Parse(typeof(WeaponClass), weaponClassName);
+            }
         }
 
         public static bool HasAnyRequiredWeapon(this BotOwner botOwner, IEnumerable<WeaponClass> requiredClasses)
@@ -74,12 +71,16 @@ namespace QuestingBots.Helpers
 
         public static IEnumerable<WeaponClass> GetEquippedWeaponClasses(this BotOwner botOwner)
         {
-            return botOwner.GetEquippedWeaponClassNames().ToWeaponClasses();
+            return botOwner.GetEquippedWeaponClassNames()
+                .ToWeaponClasses();
         }
 
         public static IEnumerable<string> GetEquippedWeaponClassNames(this BotOwner botOwner)
         {
-            return botOwner.GetEquippedWeapons().Select(w => w.WeapClass);
+            foreach (Weapon weapon in botOwner.GetEquippedWeapons())
+            {
+                yield return weapon.WeapClass;
+            }
         }
 
         public static float GetMaxWeaponSightingRange(this BotOwner botOwner)

--- a/Client/Helpers/QuestHelpers.cs
+++ b/Client/Helpers/QuestHelpers.cs
@@ -12,7 +12,7 @@ using QuestingBots.Models.Questing;
 using UnityEngine;
 using QuestingBots.Utils;
 using QuestingBots.Configuration;
-using Quest = QuestingBots.Models.Questing.Quest;
+using BotQuest = QuestingBots.Models.Questing.BotQuest;
 
 namespace QuestingBots.Helpers
 {
@@ -32,7 +32,7 @@ namespace QuestingBots.Helpers
             QuestMinLevelFinder.ClearCache();
         }
 
-        public static void ApplyQuestSettingsFromConfig(this Models.Questing.Quest quest, QuestSettingsConfig settings)
+        public static void ApplyQuestSettingsFromConfig(this Models.Questing.BotQuest quest, QuestSettingsConfig settings)
         {
             quest.Desirability = settings.Desirability;
             quest.PMCsOnly = settings.PMCsOnly;
@@ -42,7 +42,7 @@ namespace QuestingBots.Helpers
             quest.MaxLevel = settings.MaxLevel;
         }
 
-        public static void ApplyQuestSettingsFromConfig(this Models.Questing.QuestObjective objective, QuestSettingsConfig settings)
+        public static void ApplyQuestSettingsFromConfig(this Models.Questing.BotQuestObjective objective, QuestSettingsConfig settings)
         {
             objective.MinDistanceFromBot = settings.MinDistance;
             objective.MaxDistanceFromBot = settings.MaxDistance;
@@ -50,7 +50,7 @@ namespace QuestingBots.Helpers
 
         public static bool ValidateQuestFiles(string locationId)
         {
-            IEnumerable<Quest> quests = Singleton<ConfigUtil>.Instance.GetCustomQuests(locationId);
+            IEnumerable<BotQuest> quests = Singleton<ConfigUtil>.Instance.GetCustomQuests(locationId);
 
             if (!quests.Any())
             {
@@ -75,7 +75,7 @@ namespace QuestingBots.Helpers
             return zoneAndItemQuestPositions;
         }
 
-        public static IEnumerable<string> GetAllZoneIDs(this Quest quest)
+        public static IEnumerable<string> GetAllZoneIDs(this BotQuest quest)
         {
             List<string> zoneIDs = new List<string>();
             EQuestStatus eQuestStatus = EQuestStatus.AvailableForFinish;
@@ -90,7 +90,7 @@ namespace QuestingBots.Helpers
             return zoneIDs;
         }
 
-        public static float? FindPlantTime(this Quest quest, string zoneID)
+        public static float? FindPlantTime(this BotQuest quest, string zoneID)
         {
             float? plantTime = quest.findQuestValue(zoneID, FindPlantTime);
             if (plantTime.HasValue)
@@ -101,7 +101,7 @@ namespace QuestingBots.Helpers
             return null;
         }
 
-        public static float? FindBeaconTime(this Quest quest, string zoneID)
+        public static float? FindBeaconTime(this BotQuest quest, string zoneID)
         {
             float? beaconTime = quest.findQuestValue(zoneID, FindBeaconTime);
             if (beaconTime.HasValue)
@@ -112,7 +112,7 @@ namespace QuestingBots.Helpers
             return null;
         }
 
-        public static void LocateQuestItems(this Quest quest, IEnumerable<LootItem> allLoot)
+        public static void LocateQuestItems(this BotQuest quest, IEnumerable<LootItem> allLoot)
         {
             LocationData locationData = Singleton<GameWorld>.Instance.GetComponent<LocationData>();
             if (locationData == null)
@@ -139,7 +139,7 @@ namespace QuestingBots.Helpers
 
                     // Check if an objective has already been added for the item. This is to prevent duplicate objectives from being added for
                     // some EFT quests. 
-                    QuestObjective objective = quest.GetObjectiveForLootItem(target);
+                    BotQuestObjective objective = quest.GetObjectiveForLootItem(target);
                     if (objective != null)
                     {
                         continue;
@@ -219,7 +219,7 @@ namespace QuestingBots.Helpers
                     }
 
                     // Add an objective for the quest item using the nearest valid NavMesh position to it
-                    QuestObjective newObjective = new QuestItemObjective(item, navMeshTargetPoint.Value);
+                    BotQuestObjective newObjective = new BotQuestItemObjective(item, navMeshTargetPoint.Value);
                     newObjective.DoorIDToUnlock = doorIDToUnlock;
                     newObjective.InteractionPositionToUnlockDoor = interactionPositionForDoorToUnlock;
                     quest.AddObjective(newObjective);
@@ -351,7 +351,7 @@ namespace QuestingBots.Helpers
             return null;
         }
 
-        private static T findQuestValue<T>(this Quest quest, string zoneID, Func<Condition, string, T> searchMethod)
+        private static T findQuestValue<T>(this BotQuest quest, string zoneID, Func<Condition, string, T> searchMethod)
         {
             EQuestStatus eQuestStatus = EQuestStatus.AvailableForFinish;
             if (quest.Template?.Conditions?.ContainsKey(eQuestStatus) == true)

--- a/Client/Helpers/QuestHelpers.cs
+++ b/Client/Helpers/QuestHelpers.cs
@@ -12,7 +12,6 @@ using QuestingBots.Models.Questing;
 using UnityEngine;
 using QuestingBots.Utils;
 using QuestingBots.Configuration;
-using BotQuest = QuestingBots.Models.Questing.BotQuest;
 
 namespace QuestingBots.Helpers
 {

--- a/Client/Models/DebugGizmos/BotInfoGizmo.cs
+++ b/Client/Models/DebugGizmos/BotInfoGizmo.cs
@@ -100,7 +100,7 @@ namespace QuestingBots.Models.DebugGizmos
 
             bool mustQuest = (boss == null) || botQuestingDecisionMonitor.MustQuestBeforeFollowing;
 
-            BotJobAssignment? botJobAssignment = BotJobAssignmentFactory.GetCurrentJobAssignment(bot, false);
+            BotJobAssignment? botJobAssignment = botObjectiveManager.QuestSelector.GetCurrentJobAssignment(false);
             if ((botJobAssignment != null) && mustQuest)
             {
                 sb.AppendLabeledValue("Quest", botJobAssignment.QuestAssignment?.ToString(), Color.cyan, Color.cyan);

--- a/Client/Models/DebugGizmos/BotInfoGizmo.cs
+++ b/Client/Models/DebugGizmos/BotInfoGizmo.cs
@@ -100,7 +100,7 @@ namespace QuestingBots.Models.DebugGizmos
 
             bool mustQuest = (boss == null) || botQuestingDecisionMonitor.MustQuestBeforeFollowing;
 
-            BotJobAssignment? botJobAssignment = botObjectiveManager.QuestSelector.GetCurrentJobAssignment(false);
+            BotJobAssignment? botJobAssignment = botObjectiveManager.QuestSelector.GetCurrentJobAssignment();
             if ((botJobAssignment != null) && mustQuest)
             {
                 sb.AppendLabeledValue("Quest", botJobAssignment.QuestAssignment?.ToString(), Color.cyan, Color.cyan);

--- a/Client/Models/DebugGizmos/BotInfoGizmo.cs
+++ b/Client/Models/DebugGizmos/BotInfoGizmo.cs
@@ -100,13 +100,12 @@ namespace QuestingBots.Models.DebugGizmos
 
             bool mustQuest = (boss == null) || botQuestingDecisionMonitor.MustQuestBeforeFollowing;
 
-            BotJobAssignment? botJobAssignment = botObjectiveManager.QuestSelector.GetCurrentJobAssignment();
-            if ((botJobAssignment != null) && mustQuest)
+            if ((botObjectiveManager.CurrentAssignment != null) && mustQuest)
             {
-                sb.AppendLabeledValue("Quest", botJobAssignment.QuestAssignment?.ToString(), Color.cyan, Color.cyan);
-                sb.AppendLabeledValue("Objective", botJobAssignment.QuestObjectiveAssignment?.ToString(), Color.white, Color.white);
-                sb.AppendLabeledValue("Step", botJobAssignment.QuestObjectiveStepAssignment?.ToString(), Color.white, Color.white);
-                sb.AppendLabeledValue("Status", botJobAssignment.Status.ToString(), Color.white, Color.white);
+                sb.AppendLabeledValue("Quest", botObjectiveManager.CurrentAssignment.QuestAssignment?.ToString(), Color.cyan, Color.cyan);
+                sb.AppendLabeledValue("Objective", botObjectiveManager.CurrentAssignment.QuestObjectiveAssignment?.ToString(), Color.white, Color.white);
+                sb.AppendLabeledValue("Step", botObjectiveManager.CurrentAssignment.QuestObjectiveStepAssignment?.ToString(), Color.white, Color.white);
+                sb.AppendLabeledValue("Status", botObjectiveManager.CurrentAssignment.Status.ToString(), Color.white, Color.white);
             }
 
             sb.AppendLabeledValue("Current Decision", botQuestingDecisionMonitor.CurrentDecision.ToString(), Color.white, Color.white);

--- a/Client/Models/Questing/BotJobAssignment.cs
+++ b/Client/Models/Questing/BotJobAssignment.cs
@@ -67,7 +67,7 @@ namespace QuestingBots.Models.Questing
             updateBotInfo();
         }
 
-        public BotJobAssignment(BotOwner bot, Quest quest, QuestObjective objective) : this(bot)
+        public BotJobAssignment(BotOwner bot, BotQuest quest, BotQuestObjective objective) : this(bot)
         {
             QuestAssignment = quest;
             QuestObjectiveAssignment = objective;
@@ -78,7 +78,7 @@ namespace QuestingBots.Models.Questing
             }
         }
 
-        public BotJobAssignment(BotOwner bot, Quest quest, QuestObjective objective, QuestObjectiveStep step) : this(bot)
+        public BotJobAssignment(BotOwner bot, BotQuest quest, BotQuestObjective objective, BotQuestObjectiveStep step) : this(bot)
         {
             QuestAssignment = quest;
             QuestObjectiveAssignment = objective;
@@ -124,7 +124,7 @@ namespace QuestingBots.Models.Questing
                 return false;
             }
 
-            QuestObjectiveStep nextStep = QuestObjectiveAssignment.GetNextObjectiveStep(QuestObjectiveStepAssignment, allowReset);
+            BotQuestObjectiveStep nextStep = QuestObjectiveAssignment.GetNextObjectiveStep(QuestObjectiveStepAssignment, allowReset);
             if (nextStep == null)
             {
                 return false;

--- a/Client/Models/Questing/BotJobAssignment.cs
+++ b/Client/Models/Questing/BotJobAssignment.cs
@@ -186,7 +186,13 @@ namespace QuestingBots.Models.Questing
 
                 Singleton<LoggingUtil>.Instance.LogDebug("Instructing follower " + follower.GetText() + " to complete quest step " + ToString() + "...");
 
-                BotJobAssignment clonedAssignment = ObjectiveManager.CloneCurrentJobAssignment(follower);
+                BotJobAssignment? clonedAssignment = ObjectiveManager.CloneCurrentJobAssignment(follower);
+                if (clonedAssignment == null)
+                {
+                    Singleton<LoggingUtil>.Instance.LogError("Tried cloning a null assignment for follower " + follower.GetText());
+                    continue;
+                }
+
                 followerObjectiveManager.SetObjective(clonedAssignment);
             }
         }

--- a/Client/Models/Questing/BotJobAssignment.cs
+++ b/Client/Models/Questing/BotJobAssignment.cs
@@ -39,8 +39,8 @@ namespace QuestingBots.Models.Questing
 
         public bool IsActive => Status == JobAssignmentStatus.Active || Status == JobAssignmentStatus.Pending;
         public bool IsCompletedOrArchived => Status == JobAssignmentStatus.Completed || Status == JobAssignmentStatus.Archived;
-        public Vector3? LookToPosition => QuestObjectiveStepAssignment?.GetLookToPosition();
-        public Vector3? TargetPosition => QuestObjectiveStepAssignment?.GetTargetPosition();
+        public Vector3? LookToPosition => QuestObjectiveStepAssignment?.LookToPosition;
+        public Vector3? TargetPosition => QuestObjectiveStepAssignment?.TargetPosition;
         public bool IgnoreHearing => QuestObjectiveAssignment?.IgnoreHearing ?? false;
         public bool ForceUnlock => QuestObjectiveStepAssignment?.ForceUnlock ?? false;
         public bool RequireForFollowers => QuestObjectiveStepAssignment?.RequireForFollowers ?? false;

--- a/Client/Models/Questing/BotJobAssignment.cs
+++ b/Client/Models/Questing/BotJobAssignment.cs
@@ -124,7 +124,7 @@ namespace QuestingBots.Models.Questing
                 return false;
             }
 
-            BotQuestObjectiveStep nextStep = QuestObjectiveAssignment.GetNextObjectiveStep(QuestObjectiveStepAssignment, allowReset);
+            BotQuestObjectiveStep? nextStep = QuestObjectiveAssignment.GetNextObjectiveStep(QuestObjectiveStepAssignment, allowReset);
             if (nextStep == null)
             {
                 return false;

--- a/Client/Models/Questing/BotJobAssignmentCreationJob.cs
+++ b/Client/Models/Questing/BotJobAssignmentCreationJob.cs
@@ -1,0 +1,264 @@
+﻿using Comfort.Common;
+using EFT;
+using EFT.Interactive;
+using QuestingBots.BotLogic.BotMonitor.Monitors;
+using QuestingBots.Components;
+using QuestingBots.Controllers;
+using QuestingBots.Helpers;
+using QuestingBots.Utils;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace QuestingBots.Models.Questing
+{
+    public class BotJobAssignmentCreationJob
+    {
+        public bool IsCreatingAnAssignment { get; private set; } = false;
+        public bool NewAssignmentReady { get; private set; } = false;
+
+        private BotOwner _botOwner;
+        private ExfiltrationPoint _exfiltrationPoint;
+
+        private BotJobAssignment? _assignmentCreationResult = null;
+        public BotJobAssignment? AssignmentCreationResult => NewAssignmentReady ? _assignmentCreationResult : null;
+
+        public BotJobAssignmentCreationJob(BotOwner botOwner, ExfiltrationPoint exfiltrationPoint)
+        {
+            _botOwner = botOwner;
+            _exfiltrationPoint = exfiltrationPoint;
+        }
+
+        public IEnumerator CreateNewBotJobAssignment()
+        {
+            _assignmentCreationResult = null;
+            IsCreatingAnAssignment = true;
+            NewAssignmentReady = false;
+
+            try
+            {
+                BotObjectiveManager? objectiveManager = _botOwner.GetObjectiveManager();
+                if (objectiveManager == null)
+                {
+                    Singleton<LoggingUtil>.Instance.LogError("Cannot retrieve BotObjectiveManager for " + _botOwner.GetText());
+                    yield break;
+                }
+
+                float maxDistanceBetweenExfils = Singleton<GameWorld>.Instance.GetComponent<Components.LocationData>().GetMaxDistanceBetweenExfils();
+                float minDistanceToSwitchExfil = maxDistanceBetweenExfils * Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilReachedMinFraction;
+
+                // If the bot is close to its selected exfil (only used for quest selection), select a new one
+                float? distanceToExfilPoint = DistanceToExfiltrationPointForQuesting();
+                if (distanceToExfilPoint.HasValue && (distanceToExfilPoint.Value < minDistanceToSwitchExfil))
+                {
+                    objectiveManager.QuestSelector.SetExfiliationPointForQuesting();
+                }
+
+                // Get the bot's most recent assingment if applicable
+                BotJobAssignment? mostRecentAssignment = _botOwner.GetMostRecentJobAssignment();
+                BotQuest? quest = mostRecentAssignment?.QuestAssignment;
+                BotQuestObjective? objective = mostRecentAssignment?.QuestObjectiveAssignment;
+
+                // Clear the bot's assignment if it's been doing the same quest for too long
+                if ((quest?.HasBotBeingDoingQuestTooLong(_botOwner, out double? timeDoingQuest) == true) && (timeDoingQuest != null))
+                {
+                    Singleton<LoggingUtil>.Instance.LogInfo(_botOwner.GetText() + " has been performing quest " + quest.ToString() + " for " + timeDoingQuest.Value + "s and will get a new one.");
+                    quest = null;
+                    objective = null;
+                }
+
+                // Try to find a quest that has at least one objective that can be assigned to the bot
+                List<BotQuest> invalidQuests = new List<BotQuest>();
+                Stopwatch timeoutMonitor = Stopwatch.StartNew();
+                do
+                {
+                    yield return null;
+
+                    // Find the nearest objective for the bot's currently assigned quest (if any)
+                    objective = quest?
+                        .RemainingObjectivesForBot(_botOwner)?
+                        .Where(o => o.CanAssignBot(_botOwner))?
+                        .Where(o => o.CanBotRepeatQuestObjective(_botOwner))?
+                        .NearestToBot(_botOwner);
+
+                    // Exit the loop if an objective was found for the bot
+                    if (objective != null)
+                    {
+                        break;
+                    }
+                    if (quest != null)
+                    {
+                        //Singleton<LoggingUtil>.Instance.LogInfo(bot.GetText() + " cannot select quest " + quest.ToString() + " because it has no valid objectives");
+                        invalidQuests.Add(quest);
+                    }
+
+                    // If no objectives were found, select another quest
+                    quest = GetRandomQuest(invalidQuests);
+
+                    // If a quest hasn't been found within a certain amount of time, something is wrong
+                    if (timeoutMonitor.ElapsedMilliseconds > Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.QuestSelectionTimeout)
+                    {
+                        // First try allowing the bot to repeat quests it already completed
+                        if (_botOwner.TryArchiveRepeatableAssignments() > 0)
+                        {
+                            Singleton<LoggingUtil>.Instance.LogWarning(_botOwner.GetText() + " cannot select any quests. Trying to select a repeatable quest early instead...");
+                            continue;
+                        }
+
+                        // If there are still no quests available for the bot to select, give up trying to select one
+                        Singleton<LoggingUtil>.Instance.LogError(_botOwner.GetText() + " could not select any of the following quests: " + string.Join(", ", _botOwner.GetAllPossibleQuests()));
+                        objectiveManager.StopQuesting();
+
+                        // Try making the bot extract because it has nothing to do
+                        if (objectiveManager.BotMonitor.GetMonitor<BotExtractMonitor>().TryInstructBotToExtract())
+                        {
+                            Singleton<LoggingUtil>.Instance.LogWarning(_botOwner.GetText() + " cannot select any quests. Extracting instead...");
+                            yield break;
+                        }
+
+                        Singleton<LoggingUtil>.Instance.LogError(_botOwner.GetText() + " cannot select any quests. Questing disabled.");
+                        yield break;
+                    }
+
+                } while (objective == null);
+
+                if (quest != null)
+                {
+                    _assignmentCreationResult = new BotJobAssignment(_botOwner, quest, objective);
+                    _assignmentCreationResult.Register();
+                    NewAssignmentReady = true;
+                }
+                else
+                {
+                    Singleton<LoggingUtil>.Instance.LogWarning("Could not get a job assignment for bot " + _botOwner.GetText());
+                }
+            }
+            finally
+            {
+                IsCreatingAnAssignment = false;
+            }
+        }
+
+        private BotQuest GetRandomQuest(IEnumerable<BotQuest> invalidQuests)
+        {
+            if (_botOwner == null)
+            {
+                throw new ArgumentNullException("Cannot get a quest for a null bot");
+            }
+
+            Stopwatch questSelectionTimer = Stopwatch.StartNew();
+
+            BotQuest[] assignableQuests = _botOwner.GetAllPossibleQuests()
+                .Where(q => !invalidQuests.Contains(q))
+                .ToArray();
+
+            if (!assignableQuests.Any())
+            {
+                return null!;
+            }
+
+            Vector3? vectorToExfil = VectorToExfiltrationPointForQuesting();
+
+            Dictionary<BotQuest, Configuration.MinMaxConfig> questDistanceRanges = new Dictionary<BotQuest, Configuration.MinMaxConfig>();
+            Dictionary<BotQuest, Configuration.MinMaxConfig> questExfilAngleRanges = new Dictionary<BotQuest, Configuration.MinMaxConfig>();
+
+            // Calculate the distances from the bot to all valid quest objectives and the angles between the vector to the bot's selected
+            // exfil (for questing) and the vector to each valid quest objective
+            foreach (BotQuest quest in assignableQuests)
+            {
+                IEnumerable<Vector3?> objectivePositions = quest.ValidObjectives.Select(o => o.GetFirstStepPosition());
+                IEnumerable<Vector3> validObjectivePositions = objectivePositions.Where(p => p.HasValue).Select(p => p!.Value);
+                IEnumerable<float> distancesToObjectives = validObjectivePositions.Select(p => Vector3.Distance(_botOwner.Position, p));
+
+                questDistanceRanges.Add(quest, new Configuration.MinMaxConfig(distancesToObjectives.Min(), distancesToObjectives.Max()));
+
+                if (vectorToExfil.HasValue)
+                {
+                    IEnumerable<Vector3> vectorsToObjectivePositions = validObjectivePositions.Select(p => p - _botOwner.Position);
+                    IEnumerable<float> anglesToObjectives = vectorsToObjectivePositions.Select(p => Vector3.Angle(p - _botOwner.Position, vectorToExfil.Value));
+
+                    questExfilAngleRanges.Add(quest, new Configuration.MinMaxConfig(anglesToObjectives.Min(), anglesToObjectives.Max()));
+                }
+                else
+                {
+                    questExfilAngleRanges.Add(quest, new Configuration.MinMaxConfig(0, 0));
+                }
+            }
+
+            // Calculate the maximum amount of "randomness" to apply to each quest
+            //double distanceRange = questDistanceRanges.Max(q => q.Value.Max) - questDistanceRanges.Min(q => q.Value.Min);
+            double maxDistance = questDistanceRanges.Max(o => o.Value.Max);
+            int maxRandomDistance = (int)Math.Ceiling(maxDistance * Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DistanceRandomness / 100.0);
+            float maxExfilAngle = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionMaxAngle;
+
+            int distanceRandomness = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DistanceRandomness;
+            int desirabilityRandomness = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DesirabilityRandomness;
+
+            float distanceWeighting = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DistanceWeighting;
+            float desirabilityWeighting = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DesirabilityWeighting;
+            float exfilDirectionWeighting = 0;
+
+            string locationId = Singleton<GameWorld>.Instance.GetComponent<Components.LocationData>().CurrentLocation.Id;
+            if (Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionWeighting.ContainsKey(locationId))
+            {
+                exfilDirectionWeighting = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionWeighting[locationId];
+            }
+            else if (Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionWeighting.ContainsKey("default"))
+            {
+                exfilDirectionWeighting = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionWeighting["default"];
+            }
+
+            System.Random random = new System.Random();
+            Dictionary<BotQuest, double> questDistanceFractions = questDistanceRanges
+                .ToDictionary(o => o.Key, o => 1 - (o.Value.Min + random.Next(-1 * maxRandomDistance, maxRandomDistance)) / maxDistance);
+            Dictionary<BotQuest, float> questDesirabilityFractions = questDistanceRanges
+                .ToDictionary(o => o.Key, o =>
+                (
+                    o.Key.Desirability * (o.Key.IsActiveForPlayer ? Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DesirabilityActiveQuestMultiplier : 1)
+                    + random.Next(-1 * desirabilityRandomness, desirabilityRandomness)) / 100
+                );
+            Dictionary<BotQuest, double> questExfilAngleFactor = questExfilAngleRanges
+                .ToDictionary(o => o.Key, o => Math.Max(0, o.Value.Min - maxExfilAngle) / (180 - maxExfilAngle));
+
+            IEnumerable<BotQuest> sortedQuests = questDistanceRanges
+                .OrderBy
+                (o =>
+                    (questDistanceFractions[o.Key] * distanceWeighting)
+                    + (questDesirabilityFractions[o.Key] * desirabilityWeighting)
+                    - (questExfilAngleFactor[o.Key] * exfilDirectionWeighting)
+                )
+                .Select(o => o.Key);
+
+            BotQuest selectedQuest = sortedQuests.Last();
+
+            //Singleton<LoggingUtil>.Instance.LogInfo("Distance: " + questDistanceFractions[selectedQuest] + ", Desirability: " + questDesirabilityFractions[selectedQuest] + ", Exfil Angle Factor: " + questExfilAngleFactor[selectedQuest]);
+            //Singleton<LoggingUtil>.Instance.LogInfo("Time for quest selection: " + questSelectionTimer.ElapsedMilliseconds + "ms");
+
+            return selectedQuest;
+        }
+
+        private float? DistanceToExfiltrationPointForQuesting()
+        {
+            if (_exfiltrationPoint == null)
+            {
+                return null;
+            }
+
+            return Vector3.Distance(_botOwner.Position, _exfiltrationPoint.transform.position);
+        }
+
+        private Vector3? VectorToExfiltrationPointForQuesting()
+        {
+            if (_exfiltrationPoint == null)
+            {
+                return null;
+            }
+
+            return _exfiltrationPoint.transform.position - _botOwner.Position;
+        }
+    }
+}

--- a/Client/Models/Questing/BotJobAssignmentCreationJob.cs
+++ b/Client/Models/Questing/BotJobAssignmentCreationJob.cs
@@ -1,11 +1,11 @@
 ﻿using Comfort.Common;
 using EFT;
-using EFT.Interactive;
 using QuestingBots.BotLogic.BotMonitor.Monitors;
 using QuestingBots.Components;
 using QuestingBots.Controllers;
 using QuestingBots.Helpers;
 using QuestingBots.Utils;
+using QuestingBots.Utils.Benchmarking;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -18,19 +18,37 @@ namespace QuestingBots.Models.Questing
 {
     public class BotJobAssignmentCreationJob
     {
+        private const float MAX_CYCLE_TIME_MS = 1;
+
         public bool IsCreatingAnAssignment { get; private set; } = false;
         public bool NewAssignmentReady { get; private set; } = false;
 
         private BotOwner _botOwner;
-        private ExfiltrationPoint _exfiltrationPoint;
-
+        private BotObjectiveManager _objectiveManager = null!;
+        private Stopwatch _timeoutMonitor = new Stopwatch();
+        private Stopwatch _cycleTimer = new Stopwatch();
+        private System.Random _random = new System.Random();
         private BotJobAssignment? _assignmentCreationResult = null;
+        private BotQuest? _nextRandomQuest = null;
+
         public BotJobAssignment? AssignmentCreationResult => NewAssignmentReady ? _assignmentCreationResult : null;
 
-        public BotJobAssignmentCreationJob(BotOwner botOwner, ExfiltrationPoint exfiltrationPoint)
+        private bool jobHasBeenRunningTooLong => _timeoutMonitor.ElapsedMilliseconds > Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.QuestSelectionTimeout;
+        private double elapsedCycleTime => (double)_cycleTimer.ElapsedTicks / (double)Stopwatch.Frequency;
+        private bool maxCycleTimeExceeded => elapsedCycleTime > MAX_CYCLE_TIME_MS;
+
+        public BotJobAssignmentCreationJob(BotOwner botOwner)
         {
             _botOwner = botOwner;
-            _exfiltrationPoint = exfiltrationPoint;
+
+            BotObjectiveManager? objectiveManager = _botOwner.GetObjectiveManager();
+            if (objectiveManager == null)
+            {
+                Singleton<LoggingUtil>.Instance.LogError("Cannot retrieve BotObjectiveManager for " + _botOwner.GetText());
+                return;
+            }
+
+            _objectiveManager = objectiveManager;
         }
 
         public IEnumerator CreateNewBotJobAssignment()
@@ -41,94 +59,10 @@ namespace QuestingBots.Models.Questing
 
             try
             {
-                BotObjectiveManager? objectiveManager = _botOwner.GetObjectiveManager();
-                if (objectiveManager == null)
+                 yield return TryGetNextAssignment();
+
+                if (_assignmentCreationResult != null)
                 {
-                    Singleton<LoggingUtil>.Instance.LogError("Cannot retrieve BotObjectiveManager for " + _botOwner.GetText());
-                    yield break;
-                }
-
-                float maxDistanceBetweenExfils = Singleton<GameWorld>.Instance.GetComponent<Components.LocationData>().GetMaxDistanceBetweenExfils();
-                float minDistanceToSwitchExfil = maxDistanceBetweenExfils * Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilReachedMinFraction;
-
-                // If the bot is close to its selected exfil (only used for quest selection), select a new one
-                float? distanceToExfilPoint = DistanceToExfiltrationPointForQuesting();
-                if (distanceToExfilPoint.HasValue && (distanceToExfilPoint.Value < minDistanceToSwitchExfil))
-                {
-                    objectiveManager.QuestSelector.SetExfiliationPointForQuesting();
-                }
-
-                // Get the bot's most recent assingment if applicable
-                BotJobAssignment? mostRecentAssignment = _botOwner.GetMostRecentJobAssignment();
-                BotQuest? quest = mostRecentAssignment?.QuestAssignment;
-                BotQuestObjective? objective = mostRecentAssignment?.QuestObjectiveAssignment;
-
-                // Clear the bot's assignment if it's been doing the same quest for too long
-                if ((quest?.HasBotBeingDoingQuestTooLong(_botOwner, out double? timeDoingQuest) == true) && (timeDoingQuest != null))
-                {
-                    Singleton<LoggingUtil>.Instance.LogInfo(_botOwner.GetText() + " has been performing quest " + quest.ToString() + " for " + timeDoingQuest.Value + "s and will get a new one.");
-                    quest = null;
-                    objective = null;
-                }
-
-                // Try to find a quest that has at least one objective that can be assigned to the bot
-                List<BotQuest> invalidQuests = new List<BotQuest>();
-                Stopwatch timeoutMonitor = Stopwatch.StartNew();
-                do
-                {
-                    yield return null;
-
-                    // Find the nearest objective for the bot's currently assigned quest (if any)
-                    objective = quest?
-                        .RemainingObjectivesForBot(_botOwner)?
-                        .Where(o => o.CanAssignBot(_botOwner))?
-                        .Where(o => o.CanBotRepeatQuestObjective(_botOwner))?
-                        .NearestToBot(_botOwner);
-
-                    // Exit the loop if an objective was found for the bot
-                    if (objective != null)
-                    {
-                        break;
-                    }
-                    if (quest != null)
-                    {
-                        //Singleton<LoggingUtil>.Instance.LogInfo(bot.GetText() + " cannot select quest " + quest.ToString() + " because it has no valid objectives");
-                        invalidQuests.Add(quest);
-                    }
-
-                    // If no objectives were found, select another quest
-                    quest = GetRandomQuest(invalidQuests);
-
-                    // If a quest hasn't been found within a certain amount of time, something is wrong
-                    if (timeoutMonitor.ElapsedMilliseconds > Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.QuestSelectionTimeout)
-                    {
-                        // First try allowing the bot to repeat quests it already completed
-                        if (_botOwner.TryArchiveRepeatableAssignments() > 0)
-                        {
-                            Singleton<LoggingUtil>.Instance.LogWarning(_botOwner.GetText() + " cannot select any quests. Trying to select a repeatable quest early instead...");
-                            continue;
-                        }
-
-                        // If there are still no quests available for the bot to select, give up trying to select one
-                        Singleton<LoggingUtil>.Instance.LogError(_botOwner.GetText() + " could not select any of the following quests: " + string.Join(", ", _botOwner.GetAllPossibleQuests()));
-                        objectiveManager.StopQuesting();
-
-                        // Try making the bot extract because it has nothing to do
-                        if (objectiveManager.BotMonitor.GetMonitor<BotExtractMonitor>().TryInstructBotToExtract())
-                        {
-                            Singleton<LoggingUtil>.Instance.LogWarning(_botOwner.GetText() + " cannot select any quests. Extracting instead...");
-                            yield break;
-                        }
-
-                        Singleton<LoggingUtil>.Instance.LogError(_botOwner.GetText() + " cannot select any quests. Questing disabled.");
-                        yield break;
-                    }
-
-                } while (objective == null);
-
-                if (quest != null)
-                {
-                    _assignmentCreationResult = new BotJobAssignment(_botOwner, quest, objective);
                     _assignmentCreationResult.Register();
                     NewAssignmentReady = true;
                 }
@@ -143,122 +77,213 @@ namespace QuestingBots.Models.Questing
             }
         }
 
-        private BotQuest GetRandomQuest(IEnumerable<BotQuest> invalidQuests)
+        private IEnumerator TryGetNextAssignment()
         {
-            if (_botOwner == null)
+            _timeoutMonitor.Restart();
+            _cycleTimer.Restart();
+
+            BotJobAssignment? mostRecentAssignment = _botOwner.GetMostRecentJobAssignment();
+            BotQuest? quest = mostRecentAssignment?.QuestAssignment;
+            BotQuestObjective? objective = GetNextObjectiveForQuest(quest);
+
+            while ((quest == null) || (objective == null))
             {
-                throw new ArgumentNullException("Cannot get a quest for a null bot");
+                yield return ChooseNextRandomQuest();
+
+                quest = _nextRandomQuest;
+                objective = GetNextObjectiveForQuest(quest);
+                
+                // If a quest hasn't been found within a certain amount of time, something is wrong
+                if ((objective == null) && jobHasBeenRunningTooLong)
+                {
+                    Singleton<LoggingUtil>.Instance.LogWarning("Waited " + _timeoutMonitor.ElapsedMilliseconds + "ms to select a quest for " + _botOwner.GetText());
+
+                    // First try allowing the bot to repeat quests it already completed
+                    if (_botOwner.TryArchiveRepeatableAssignments() > 0)
+                    {
+                        Singleton<LoggingUtil>.Instance.LogWarning(_botOwner.GetText() + " cannot select any quests. Trying to select a repeatable quest early instead...");
+                        continue;
+                    }
+
+                    StopQuestingAndExtract();
+                    yield break;
+                }
             }
 
-            Stopwatch questSelectionTimer = Stopwatch.StartNew();
+            Singleton<LoggingUtil>.Instance.LogDebug("Waited " + _timeoutMonitor.ElapsedMilliseconds + "ms to select a quest for " + _botOwner.GetText());
+            _assignmentCreationResult = new BotJobAssignment(_botOwner, quest, objective);
+        }
 
-            BotQuest[] assignableQuests = _botOwner.GetAllPossibleQuests()
-                .Where(q => !invalidQuests.Contains(q))
-                .ToArray();
+        [Benchmark]
+        private BotQuestObjective? GetNextObjectiveForQuest(BotQuest? quest)
+        {
+            if (quest == null)
+            {
+                return null;
+            }
 
+            // Clear the bot's assignment if it's been doing the same quest for too long
+            if ((quest.HasBotBeingDoingQuestTooLong(_botOwner, out double? timeDoingQuest) == true) && (timeDoingQuest != null))
+            {
+                Singleton<LoggingUtil>.Instance.LogInfo(_botOwner.GetText() + " has been performing quest " + quest.ToString() + " for " + timeDoingQuest.Value + "s and will get a new one.");
+                return null;
+            }
+
+            return quest
+                .RemainingObjectivesForBot(_botOwner)
+                .Where(o => o.CanAssignBot(_botOwner))
+                .Where(o => o.CanBotRepeatQuestObjective(_botOwner))
+                .NearestToBot(_botOwner);
+        }
+
+        private void StopQuestingAndExtract()
+        {
+            // If there are still no quests available for the bot to select, give up trying to select one
+            Singleton<LoggingUtil>.Instance.LogError(_botOwner.GetText() + " could not select any of the following quests: " + string.Join(", ", _botOwner.GetAllPossibleQuests()));
+            _objectiveManager.StopQuesting();
+
+            // Try making the bot extract because it has nothing to do
+            if (_objectiveManager.BotMonitor.GetMonitor<BotExtractMonitor>().TryInstructBotToExtract())
+            {
+                Singleton<LoggingUtil>.Instance.LogWarning(_botOwner.GetText() + " cannot select any quests. Extracting instead...");
+                return;
+            }
+
+            Singleton<LoggingUtil>.Instance.LogError(_botOwner.GetText() + " cannot select any quests. Questing disabled.");
+        }
+
+        private IEnumerator ChooseNextRandomQuest()
+        {
+            _nextRandomQuest = null;
+
+            IEnumerable<BotQuest> assignableQuests = _botOwner.GetAllPossibleQuests();
             if (!assignableQuests.Any())
             {
-                return null!;
+                yield break;
             }
 
-            Vector3? vectorToExfil = VectorToExfiltrationPointForQuesting();
+            Dictionary<BotQuest, Configuration.MinMaxConfig> questDistanceRanges = GetQuestDistanceRanges(assignableQuests);
+            Dictionary<BotQuest, Configuration.MinMaxConfig> questExfilAngleRanges = GetQuestExfilAngleRanges(assignableQuests);
 
-            Dictionary<BotQuest, Configuration.MinMaxConfig> questDistanceRanges = new Dictionary<BotQuest, Configuration.MinMaxConfig>();
-            Dictionary<BotQuest, Configuration.MinMaxConfig> questExfilAngleRanges = new Dictionary<BotQuest, Configuration.MinMaxConfig>();
-
-            // Calculate the distances from the bot to all valid quest objectives and the angles between the vector to the bot's selected
-            // exfil (for questing) and the vector to each valid quest objective
-            foreach (BotQuest quest in assignableQuests)
-            {
-                IEnumerable<Vector3?> objectivePositions = quest.ValidObjectives.Select(o => o.GetFirstStepPosition());
-                IEnumerable<Vector3> validObjectivePositions = objectivePositions.Where(p => p.HasValue).Select(p => p!.Value);
-                IEnumerable<float> distancesToObjectives = validObjectivePositions.Select(p => Vector3.Distance(_botOwner.Position, p));
-
-                questDistanceRanges.Add(quest, new Configuration.MinMaxConfig(distancesToObjectives.Min(), distancesToObjectives.Max()));
-
-                if (vectorToExfil.HasValue)
-                {
-                    IEnumerable<Vector3> vectorsToObjectivePositions = validObjectivePositions.Select(p => p - _botOwner.Position);
-                    IEnumerable<float> anglesToObjectives = vectorsToObjectivePositions.Select(p => Vector3.Angle(p - _botOwner.Position, vectorToExfil.Value));
-
-                    questExfilAngleRanges.Add(quest, new Configuration.MinMaxConfig(anglesToObjectives.Min(), anglesToObjectives.Max()));
-                }
-                else
-                {
-                    questExfilAngleRanges.Add(quest, new Configuration.MinMaxConfig(0, 0));
-                }
-            }
-
-            // Calculate the maximum amount of "randomness" to apply to each quest
-            //double distanceRange = questDistanceRanges.Max(q => q.Value.Max) - questDistanceRanges.Min(q => q.Value.Min);
             double maxDistance = questDistanceRanges.Max(o => o.Value.Max);
-            int maxRandomDistance = (int)Math.Ceiling(maxDistance * Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DistanceRandomness / 100.0);
+            int distanceRandomness = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DistanceRandomness;
+            int maxRandomDistance = (int)Math.Ceiling(maxDistance * distanceRandomness / 100.0);
             float maxExfilAngle = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionMaxAngle;
 
-            int distanceRandomness = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DistanceRandomness;
             int desirabilityRandomness = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DesirabilityRandomness;
 
             float distanceWeighting = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DistanceWeighting;
             float desirabilityWeighting = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DesirabilityWeighting;
-            float exfilDirectionWeighting = 0;
+            float exfilDirectionWeighting = GetExfilWeighting();
 
+            Dictionary<BotQuest, double> questWeights = new Dictionary<BotQuest, double>();
+            foreach (BotQuest quest in assignableQuests)
+            {
+                Configuration.MinMaxConfig distanceRange = questDistanceRanges[quest];
+                Configuration.MinMaxConfig exfilAngleRange = questExfilAngleRanges[quest];
+
+                double distanceFraction = 1 - ((distanceRange.Min + _random.Next(-1 * maxRandomDistance, maxRandomDistance)) / maxDistance);
+                double desirabilityFraction = (quest.Desirability * DesirabilityMultiplier(quest) + _random.Next(-1 * desirabilityRandomness, desirabilityRandomness)) / 100;
+                double exfilAngleFactor = Math.Max(0, exfilAngleRange.Min - maxExfilAngle) / (180 - maxExfilAngle);
+
+                double weight = (distanceFraction * distanceWeighting) + (desirabilityFraction * desirabilityWeighting) + (exfilAngleFactor * exfilDirectionWeighting);
+                questWeights.Add(quest, weight);
+
+                yield return HasReachMaxCalculationTimeForFrame();
+            }
+
+            _nextRandomQuest = questWeights
+                .OrderBy(o => o.Value)
+                .Last().Key;
+
+            //Singleton<LoggingUtil>.Instance.LogInfo("Distance: " + questDistanceFractions[selectedQuest] + ", Desirability: " + questDesirabilityFractions[selectedQuest] + ", Exfil Angle Factor: " + questExfilAngleFactor[selectedQuest]);
+        }
+
+        private IEnumerator HasReachMaxCalculationTimeForFrame()
+        {
+            if (maxCycleTimeExceeded)
+            {
+                yield return null;
+                _cycleTimer.Restart();
+            }
+        }
+
+        [Benchmark]
+        private Dictionary<BotQuest, Configuration.MinMaxConfig> GetQuestDistanceRanges(IEnumerable<BotQuest> quests)
+        {
+            Dictionary<BotQuest, Configuration.MinMaxConfig> questDistanceRanges = new Dictionary<BotQuest, Configuration.MinMaxConfig>();
+
+            foreach (BotQuest quest in quests)
+            {
+                IEnumerable<Vector3> validObjectivePositions = GetValidObjectivePositions(quest);
+                IEnumerable<float> distancesToObjectives = validObjectivePositions.Select(p => Vector3.Distance(_botOwner.Position, p));
+
+                questDistanceRanges.Add(quest, new Configuration.MinMaxConfig(distancesToObjectives.Min(), distancesToObjectives.Max()));
+            }
+
+            return questDistanceRanges;
+        }
+
+        [Benchmark]
+        private Dictionary<BotQuest, Configuration.MinMaxConfig> GetQuestExfilAngleRanges(IEnumerable<BotQuest> quests)
+        {
+            Dictionary<BotQuest, Configuration.MinMaxConfig> questExfilAngleRanges = new Dictionary<BotQuest, Configuration.MinMaxConfig>();
+
+            Vector3? vectorToExfil = _objectiveManager.QuestSelector.VectorToExfiltrationPointForQuesting();
+
+            foreach (BotQuest quest in quests)
+            {
+                if (vectorToExfil == null)
+                {
+                    questExfilAngleRanges.Add(quest, new Configuration.MinMaxConfig(0, 0));
+                    continue;
+                }
+
+                IEnumerable<Vector3> validObjectivePositions = GetValidObjectivePositions(quest);
+                IEnumerable<Vector3> vectorsToObjectivePositions = validObjectivePositions.Select(p => p - _botOwner.Position);
+                IEnumerable<float> anglesToObjectives = vectorsToObjectivePositions.Select(p => Vector3.Angle(p - _botOwner.Position, vectorToExfil.Value));
+
+                questExfilAngleRanges.Add(quest, new Configuration.MinMaxConfig(anglesToObjectives.Min(), anglesToObjectives.Max()));
+            }
+
+            return questExfilAngleRanges;
+        }
+
+        private IEnumerable<Vector3> GetValidObjectivePositions(BotQuest quest)
+        {
+            foreach (BotQuestObjective objective in quest.ValidObjectives)
+            {
+                Vector3? firstPosition = objective.GetFirstStepPosition();
+                if (firstPosition.HasValue)
+                {
+                    yield return firstPosition.Value;
+                }
+            }
+        }
+
+        private float DesirabilityMultiplier(BotQuest quest)
+        {
+            if (quest.IsActiveForPlayer)
+            {
+                return Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DesirabilityActiveQuestMultiplier;
+            }
+
+            return 1;
+        }
+
+        private float GetExfilWeighting()
+        {
             string locationId = Singleton<GameWorld>.Instance.GetComponent<Components.LocationData>().CurrentLocation.Id;
             if (Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionWeighting.ContainsKey(locationId))
             {
-                exfilDirectionWeighting = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionWeighting[locationId];
+                return Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionWeighting[locationId];
             }
             else if (Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionWeighting.ContainsKey("default"))
             {
-                exfilDirectionWeighting = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionWeighting["default"];
+                return Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionWeighting["default"];
             }
 
-            System.Random random = new System.Random();
-            Dictionary<BotQuest, double> questDistanceFractions = questDistanceRanges
-                .ToDictionary(o => o.Key, o => 1 - (o.Value.Min + random.Next(-1 * maxRandomDistance, maxRandomDistance)) / maxDistance);
-            Dictionary<BotQuest, float> questDesirabilityFractions = questDistanceRanges
-                .ToDictionary(o => o.Key, o =>
-                (
-                    o.Key.Desirability * (o.Key.IsActiveForPlayer ? Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DesirabilityActiveQuestMultiplier : 1)
-                    + random.Next(-1 * desirabilityRandomness, desirabilityRandomness)) / 100
-                );
-            Dictionary<BotQuest, double> questExfilAngleFactor = questExfilAngleRanges
-                .ToDictionary(o => o.Key, o => Math.Max(0, o.Value.Min - maxExfilAngle) / (180 - maxExfilAngle));
-
-            IEnumerable<BotQuest> sortedQuests = questDistanceRanges
-                .OrderBy
-                (o =>
-                    (questDistanceFractions[o.Key] * distanceWeighting)
-                    + (questDesirabilityFractions[o.Key] * desirabilityWeighting)
-                    - (questExfilAngleFactor[o.Key] * exfilDirectionWeighting)
-                )
-                .Select(o => o.Key);
-
-            BotQuest selectedQuest = sortedQuests.Last();
-
-            //Singleton<LoggingUtil>.Instance.LogInfo("Distance: " + questDistanceFractions[selectedQuest] + ", Desirability: " + questDesirabilityFractions[selectedQuest] + ", Exfil Angle Factor: " + questExfilAngleFactor[selectedQuest]);
-            //Singleton<LoggingUtil>.Instance.LogInfo("Time for quest selection: " + questSelectionTimer.ElapsedMilliseconds + "ms");
-
-            return selectedQuest;
-        }
-
-        private float? DistanceToExfiltrationPointForQuesting()
-        {
-            if (_exfiltrationPoint == null)
-            {
-                return null;
-            }
-
-            return Vector3.Distance(_botOwner.Position, _exfiltrationPoint.transform.position);
-        }
-
-        private Vector3? VectorToExfiltrationPointForQuesting()
-        {
-            if (_exfiltrationPoint == null)
-            {
-                return null;
-            }
-
-            return _exfiltrationPoint.transform.position - _botOwner.Position;
+            return 0;
         }
     }
 }

--- a/Client/Models/Questing/BotJobAssignmentCreationJob.cs
+++ b/Client/Models/Questing/BotJobAssignmentCreationJob.cs
@@ -18,8 +18,6 @@ namespace QuestingBots.Models.Questing
 {
     public class BotJobAssignmentCreationJob : IBotJobAssignmentCreationJob
     {
-        private const float MAX_CYCLE_TIME_MS = 1;
-
         public bool IsCreatingAnAssignment { get; private set; } = false;
         public bool NewAssignmentReady { get; private set; } = false;
 
@@ -35,9 +33,16 @@ namespace QuestingBots.Models.Questing
 
         public BotJobAssignment? AssignmentCreationResult => NewAssignmentReady ? _assignmentCreationResult : null;
 
-        private bool jobHasBeenRunningTooLong => _timeoutMonitor.ElapsedMilliseconds > Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.QuestSelectionTimeout;
+        private bool jobHasBeenRunningTooLong => _timeoutMonitor.ElapsedMilliseconds > Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.QuestSelection.Timeout;
         private double elapsedCycleTime => (double)_cycleTimer.ElapsedTicks / (double)Stopwatch.Frequency;
-        private bool maxCycleTimeExceeded => elapsedCycleTime > MAX_CYCLE_TIME_MS;
+        private bool maxCycleTimeExceeded => elapsedCycleTime > Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.QuestSelection.MaxCalcTimePerFrame;
+
+        private int _distanceRandomness => Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DistanceRandomness;
+        private float _maxExfilAngle => Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionMaxAngle;
+        private int _desirabilityRandomness => Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DesirabilityRandomness;
+        private float _distanceWeighting => Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DistanceWeighting;
+        private float _desirabilityWeighting => Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DesirabilityWeighting;
+        private Dictionary<string, float> _exfilDirectionWeighting => Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionWeighting;
 
         public BotJobAssignmentCreationJob(BotOwner botOwner)
         {
@@ -211,14 +216,7 @@ namespace QuestingBots.Models.Questing
             yield return HasReachMaxCalculationTimeForFrame();
 
             double maxDistance = questDistanceRanges.Max(o => o.Value.Max);
-            int distanceRandomness = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DistanceRandomness;
-            int maxRandomDistance = (int)Math.Ceiling(maxDistance * distanceRandomness / 100.0);
-            float maxExfilAngle = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionMaxAngle;
-
-            int desirabilityRandomness = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DesirabilityRandomness;
-
-            float distanceWeighting = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DistanceWeighting;
-            float desirabilityWeighting = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DesirabilityWeighting;
+            int maxRandomDistance = (int)Math.Ceiling(maxDistance * _distanceRandomness / 100.0);
             float exfilDirectionWeighting = GetExfilWeighting();
 
             double maxWeight = double.MinValue;
@@ -228,10 +226,10 @@ namespace QuestingBots.Models.Questing
                 Configuration.MinMaxConfig exfilAngleRange = questExfilAngleRanges[quest];
 
                 double distanceFraction = 1 - ((distanceRange.Min + _random.Next(-1 * maxRandomDistance, maxRandomDistance)) / maxDistance);
-                double desirabilityFraction = (quest.Desirability * DesirabilityMultiplier(quest) + _random.Next(-1 * desirabilityRandomness, desirabilityRandomness)) / 100;
-                double exfilAngleFactor = Math.Max(0, exfilAngleRange.Min - maxExfilAngle) / (180 - maxExfilAngle);
+                double desirabilityFraction = (quest.Desirability * DesirabilityMultiplier(quest) + _random.Next(-1 * _desirabilityRandomness, _desirabilityRandomness)) / 100;
+                double exfilAngleFactor = Math.Max(0, exfilAngleRange.Min - _maxExfilAngle) / (180 - _maxExfilAngle);
 
-                double weight = (distanceFraction * distanceWeighting) + (desirabilityFraction * desirabilityWeighting) + (exfilAngleFactor * exfilDirectionWeighting);
+                double weight = (distanceFraction * _distanceWeighting) + (desirabilityFraction * _desirabilityWeighting) + (exfilAngleFactor * exfilDirectionWeighting);
                 if (weight > maxWeight)
                 {
                     _nextRandomQuest = quest;
@@ -251,7 +249,6 @@ namespace QuestingBots.Models.Questing
             }
         }
 
-        [Benchmark]
         private Dictionary<BotQuest, Configuration.MinMaxConfig> GetQuestDistanceRanges(IEnumerable<BotQuest> quests)
         {
             Dictionary<BotQuest, Configuration.MinMaxConfig> questDistanceRanges = new Dictionary<BotQuest, Configuration.MinMaxConfig>();
@@ -288,7 +285,6 @@ namespace QuestingBots.Models.Questing
             return questDistanceRanges;
         }
 
-        [Benchmark]
         private Dictionary<BotQuest, Configuration.MinMaxConfig> GetQuestExfilAngleRanges(IEnumerable<BotQuest> quests)
         {
             Dictionary<BotQuest, Configuration.MinMaxConfig> questExfilAngleRanges = new Dictionary<BotQuest, Configuration.MinMaxConfig>();
@@ -360,13 +356,14 @@ namespace QuestingBots.Models.Questing
         private float GetExfilWeighting()
         {
             string locationId = Singleton<GameWorld>.Instance.GetComponent<Components.LocationData>().CurrentLocation.Id;
-            if (Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionWeighting.ContainsKey(locationId))
+
+            if (_exfilDirectionWeighting.ContainsKey(locationId))
             {
-                return Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionWeighting[locationId];
+                return _exfilDirectionWeighting[locationId];
             }
-            else if (Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionWeighting.ContainsKey("default"))
+            else if (_exfilDirectionWeighting.ContainsKey("default"))
             {
-                return Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.ExfilDirectionWeighting["default"];
+                return _exfilDirectionWeighting["default"];
             }
 
             return 0;

--- a/Client/Models/Questing/BotJobAssignmentCreationJob.cs
+++ b/Client/Models/Questing/BotJobAssignmentCreationJob.cs
@@ -16,7 +16,7 @@ using UnityEngine;
 
 namespace QuestingBots.Models.Questing
 {
-    public class BotJobAssignmentCreationJob
+    public class BotJobAssignmentCreationJob : IBotJobAssignmentCreationJob
     {
         private const float MAX_CYCLE_TIME_MS = 1;
 
@@ -250,6 +250,8 @@ namespace QuestingBots.Models.Questing
                 if (!validObjectivePositions.Any())
                 {
                     Singleton<LoggingUtil>.Instance.LogWarning("No valid positions found for quest " + quest.ToString());
+
+                    questDistanceRanges.Add(quest, new Configuration.MinMaxConfig(float.MaxValue, float.MaxValue));
                     continue;
                 }
 
@@ -285,7 +287,7 @@ namespace QuestingBots.Models.Questing
             {
                 if (vectorToExfil == null)
                 {
-                    questExfilAngleRanges.Add(quest, new Configuration.MinMaxConfig(0, 0));
+                    questExfilAngleRanges.Add(quest, new Configuration.MinMaxConfig(float.MaxValue, float.MaxValue));
                     continue;
                 }
 
@@ -293,6 +295,8 @@ namespace QuestingBots.Models.Questing
                 if (!validObjectivePositions.Any())
                 {
                     Singleton<LoggingUtil>.Instance.LogWarning("No valid positions found for quest " + quest.ToString());
+
+                    questExfilAngleRanges.Add(quest, new Configuration.MinMaxConfig(float.MaxValue, float.MaxValue));
                     continue;
                 }
 

--- a/Client/Models/Questing/BotJobAssignmentCreationJob.cs
+++ b/Client/Models/Questing/BotJobAssignmentCreationJob.cs
@@ -186,8 +186,8 @@ namespace QuestingBots.Models.Questing
         {
             _nextRandomQuest = null;
 
-            IEnumerable<BotQuest> assignableQuests = _botOwner.GetAllPossibleQuests();
-            if (!assignableQuests.Any())
+            BotQuest[] assignableQuests = _botOwner.GetAllPossibleQuests().ToArray();
+            if (assignableQuests.Length == 0)
             {
                 yield break;
             }

--- a/Client/Models/Questing/BotJobAssignmentCreationJob.cs
+++ b/Client/Models/Questing/BotJobAssignmentCreationJob.cs
@@ -25,11 +25,13 @@ namespace QuestingBots.Models.Questing
 
         private BotOwner _botOwner;
         private BotObjectiveManager _objectiveManager = null!;
+        private List<BotQuest> availableQuests = new List<BotQuest>();
         private Stopwatch _timeoutMonitor = new Stopwatch();
         private Stopwatch _cycleTimer = new Stopwatch();
         private System.Random _random = new System.Random();
         private BotJobAssignment? _assignmentCreationResult = null;
         private BotQuest? _nextRandomQuest = null;
+        
 
         public BotJobAssignment? AssignmentCreationResult => NewAssignmentReady ? _assignmentCreationResult : null;
 
@@ -59,7 +61,11 @@ namespace QuestingBots.Models.Questing
 
             try
             {
-                 yield return TryGetNextAssignment();
+                RefreshAvailableQuests();
+                if (availableQuests.Count > 0)
+                {
+                    yield return TryGetNextAssignment();
+                }
 
                 if (_assignmentCreationResult != null)
                 {
@@ -77,6 +83,12 @@ namespace QuestingBots.Models.Questing
             }
         }
 
+        [Benchmark]
+        private void RefreshAvailableQuests()
+        {
+            availableQuests = _botOwner.GetAllPossibleQuests().ToList();
+        }
+
         private IEnumerator TryGetNextAssignment()
         {
             _timeoutMonitor.Restart();
@@ -92,6 +104,12 @@ namespace QuestingBots.Models.Questing
 
                 quest = _nextRandomQuest;
                 objective = GetNextObjectiveForQuest(quest);
+
+                if ((objective == null) && (quest != null))
+                {
+                    //Singleton<LoggingUtil>.Instance.LogDebug("Temporarily blacklisted unavailable quest " + quest.ToString() + " for " + _botOwner.GetText());
+                    availableQuests.Remove(quest);
+                }
                 
                 // If a quest hasn't been found within a certain amount of time, something is wrong
                 if ((objective == null) && jobHasBeenRunningTooLong)
@@ -169,7 +187,7 @@ namespace QuestingBots.Models.Questing
         private void StopQuestingAndExtract()
         {
             // If there are still no quests available for the bot to select, give up trying to select one
-            Singleton<LoggingUtil>.Instance.LogError(_botOwner.GetText() + " could not select any of the following quests: " + string.Join(", ", _botOwner.GetAllPossibleQuests()));
+            Singleton<LoggingUtil>.Instance.LogError(_botOwner.GetText() + " could not select any of the following quests: " + string.Join(", ", availableQuests));
             _objectiveManager.StopQuesting();
 
             // Try making the bot extract because it has nothing to do
@@ -186,16 +204,10 @@ namespace QuestingBots.Models.Questing
         {
             _nextRandomQuest = null;
 
-            BotQuest[] assignableQuests = _botOwner.GetAllPossibleQuests().ToArray();
-            if (assignableQuests.Length == 0)
-            {
-                yield break;
-            }
-
-            Dictionary<BotQuest, Configuration.MinMaxConfig> questDistanceRanges = GetQuestDistanceRanges(assignableQuests);
+            Dictionary<BotQuest, Configuration.MinMaxConfig> questDistanceRanges = GetQuestDistanceRanges(availableQuests);
             yield return HasReachMaxCalculationTimeForFrame();
 
-            Dictionary<BotQuest, Configuration.MinMaxConfig> questExfilAngleRanges = GetQuestExfilAngleRanges(assignableQuests);
+            Dictionary<BotQuest, Configuration.MinMaxConfig> questExfilAngleRanges = GetQuestExfilAngleRanges(availableQuests);
             yield return HasReachMaxCalculationTimeForFrame();
 
             double maxDistance = questDistanceRanges.Max(o => o.Value.Max);
@@ -210,7 +222,7 @@ namespace QuestingBots.Models.Questing
             float exfilDirectionWeighting = GetExfilWeighting();
 
             double maxWeight = double.MinValue;
-            foreach (BotQuest quest in assignableQuests)
+            foreach (BotQuest quest in availableQuests)
             {
                 Configuration.MinMaxConfig distanceRange = questDistanceRanges[quest];
                 Configuration.MinMaxConfig exfilAngleRange = questExfilAngleRanges[quest];

--- a/Client/Models/Questing/BotJobAssignmentCreationJob.cs
+++ b/Client/Models/Questing/BotJobAssignmentCreationJob.cs
@@ -123,17 +123,47 @@ namespace QuestingBots.Models.Questing
             }
 
             // Clear the bot's assignment if it's been doing the same quest for too long
-            if ((quest.HasBotBeingDoingQuestTooLong(_botOwner, out double? timeDoingQuest) == true) && (timeDoingQuest != null))
+            if (quest.HasBotBeingDoingQuestTooLong(_botOwner, out double? timeDoingQuest) && (timeDoingQuest != null))
             {
                 Singleton<LoggingUtil>.Instance.LogInfo(_botOwner.GetText() + " has been performing quest " + quest.ToString() + " for " + timeDoingQuest.Value + "s and will get a new one.");
                 return null;
             }
 
-            return quest
-                .RemainingObjectivesForBot(_botOwner)
-                .Where(o => o.CanAssignBot(_botOwner))
-                .Where(o => o.CanBotRepeatQuestObjective(_botOwner))
-                .NearestToBot(_botOwner);
+            IEnumerable<BotQuestObjective> remainingObjectives = quest.RemainingObjectivesForBot(_botOwner);
+            return GetNearestAssignableObjective(remainingObjectives);
+        }
+
+        private BotQuestObjective? GetNearestAssignableObjective(IEnumerable<BotQuestObjective> assignableObjectives)
+        {
+            BotQuestObjective? nearestObjective = null;
+            float nearestObjectiveDistance = float.MaxValue;
+            foreach (BotQuestObjective objective in assignableObjectives)
+            {
+                if (!objective.CanAssignBot(_botOwner))
+                {
+                    continue;
+                }
+
+                if (!objective.CanBotSelectQuestObjective(_botOwner))
+                {
+                    continue;
+                }
+
+                Vector3? firstStepPosition = objective.GetFirstStepPosition();
+                if (firstStepPosition == null)
+                {
+                    continue;
+                }
+
+                float objectiveDistance = Vector3.Distance(_botOwner.Position, firstStepPosition.Value);
+                if (objectiveDistance < nearestObjectiveDistance)
+                {
+                    nearestObjective = objective;
+                    nearestObjectiveDistance = objectiveDistance;
+                }
+            }
+
+            return nearestObjective;
         }
 
         private void StopQuestingAndExtract()
@@ -163,7 +193,10 @@ namespace QuestingBots.Models.Questing
             }
 
             Dictionary<BotQuest, Configuration.MinMaxConfig> questDistanceRanges = GetQuestDistanceRanges(assignableQuests);
+            yield return HasReachMaxCalculationTimeForFrame();
+
             Dictionary<BotQuest, Configuration.MinMaxConfig> questExfilAngleRanges = GetQuestExfilAngleRanges(assignableQuests);
+            yield return HasReachMaxCalculationTimeForFrame();
 
             double maxDistance = questDistanceRanges.Max(o => o.Value.Max);
             int distanceRandomness = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DistanceRandomness;
@@ -176,7 +209,7 @@ namespace QuestingBots.Models.Questing
             float desirabilityWeighting = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuests.DesirabilityWeighting;
             float exfilDirectionWeighting = GetExfilWeighting();
 
-            Dictionary<BotQuest, double> questWeights = new Dictionary<BotQuest, double>();
+            double maxWeight = double.MinValue;
             foreach (BotQuest quest in assignableQuests)
             {
                 Configuration.MinMaxConfig distanceRange = questDistanceRanges[quest];
@@ -187,16 +220,14 @@ namespace QuestingBots.Models.Questing
                 double exfilAngleFactor = Math.Max(0, exfilAngleRange.Min - maxExfilAngle) / (180 - maxExfilAngle);
 
                 double weight = (distanceFraction * distanceWeighting) + (desirabilityFraction * desirabilityWeighting) + (exfilAngleFactor * exfilDirectionWeighting);
-                questWeights.Add(quest, weight);
+                if (weight > maxWeight)
+                {
+                    _nextRandomQuest = quest;
+                    maxWeight = weight;
+                }
 
                 yield return HasReachMaxCalculationTimeForFrame();
             }
-
-            _nextRandomQuest = questWeights
-                .OrderBy(o => o.Value)
-                .Last().Key;
-
-            //Singleton<LoggingUtil>.Instance.LogInfo("Distance: " + questDistanceFractions[selectedQuest] + ", Desirability: " + questDesirabilityFractions[selectedQuest] + ", Exfil Angle Factor: " + questExfilAngleFactor[selectedQuest]);
         }
 
         private IEnumerator HasReachMaxCalculationTimeForFrame()
@@ -216,9 +247,28 @@ namespace QuestingBots.Models.Questing
             foreach (BotQuest quest in quests)
             {
                 IEnumerable<Vector3> validObjectivePositions = GetValidObjectivePositions(quest);
-                IEnumerable<float> distancesToObjectives = validObjectivePositions.Select(p => Vector3.Distance(_botOwner.Position, p));
+                if (!validObjectivePositions.Any())
+                {
+                    Singleton<LoggingUtil>.Instance.LogWarning("No valid positions found for quest " + quest.ToString());
+                    continue;
+                }
 
-                questDistanceRanges.Add(quest, new Configuration.MinMaxConfig(distancesToObjectives.Min(), distancesToObjectives.Max()));
+                float minDistance = float.MaxValue;
+                float maxDistance = 0;
+                foreach (Vector3 objectivePosition in validObjectivePositions)
+                {
+                    float distance = Vector3.Distance(_botOwner.Position, objectivePosition);
+                    if (distance < minDistance)
+                    {
+                        minDistance = distance;
+                    }
+                    if (distance > maxDistance)
+                    {
+                        maxDistance = distance;
+                    }
+                }
+
+                questDistanceRanges.Add(quest, new Configuration.MinMaxConfig(minDistance, maxDistance));
             }
 
             return questDistanceRanges;
@@ -240,10 +290,28 @@ namespace QuestingBots.Models.Questing
                 }
 
                 IEnumerable<Vector3> validObjectivePositions = GetValidObjectivePositions(quest);
-                IEnumerable<Vector3> vectorsToObjectivePositions = validObjectivePositions.Select(p => p - _botOwner.Position);
-                IEnumerable<float> anglesToObjectives = vectorsToObjectivePositions.Select(p => Vector3.Angle(p - _botOwner.Position, vectorToExfil.Value));
+                if (!validObjectivePositions.Any())
+                {
+                    Singleton<LoggingUtil>.Instance.LogWarning("No valid positions found for quest " + quest.ToString());
+                    continue;
+                }
 
-                questExfilAngleRanges.Add(quest, new Configuration.MinMaxConfig(anglesToObjectives.Min(), anglesToObjectives.Max()));
+                float minAngle = float.MaxValue;
+                float maxAngle = float.MinValue;
+                foreach (Vector3 objectivePosition in validObjectivePositions)
+                {
+                    float angle = Vector3.Angle(objectivePosition - _botOwner.Position, vectorToExfil.Value);
+                    if (angle < minAngle)
+                    {
+                        minAngle = angle;
+                    }
+                    if (angle > maxAngle)
+                    {
+                        maxAngle = angle;
+                    }
+                }
+
+                questExfilAngleRanges.Add(quest, new Configuration.MinMaxConfig(minAngle, maxAngle));
             }
 
             return questExfilAngleRanges;
@@ -251,13 +319,15 @@ namespace QuestingBots.Models.Questing
 
         private IEnumerable<Vector3> GetValidObjectivePositions(BotQuest quest)
         {
-            foreach (BotQuestObjective objective in quest.ValidObjectives)
+            foreach (BotQuestObjective objective in quest.GetValidObjectives())
             {
                 Vector3? firstPosition = objective.GetFirstStepPosition();
-                if (firstPosition.HasValue)
+                if (firstPosition == null)
                 {
-                    yield return firstPosition.Value;
+                    continue;
                 }
+
+                yield return firstPosition.Value;
             }
         }
 

--- a/Client/Models/Questing/BotQuest.cs
+++ b/Client/Models/Questing/BotQuest.cs
@@ -16,7 +16,7 @@ using UnityEngine;
 
 namespace QuestingBots.Models.Questing
 {
-    public class Quest : JSONObject<Quest>
+    public class BotQuest : JSONObject<BotQuest>
     {
         [JsonProperty("repeatable")]
         public bool IsRepeatable { get; set; } = false;
@@ -82,7 +82,7 @@ namespace QuestingBots.Models.Questing
         private SerializableVector3[] serializableWaypointPositions { get; set; } = new SerializableVector3[0];
 
         [JsonProperty("objectives")]
-        private QuestObjective[] objectives { get; set; } = new QuestObjective[0];
+        private BotQuestObjective[] objectives { get; set; } = new BotQuestObjective[0];
 
         [JsonIgnore]
         private IList<Vector3> waypointPositions = null!;
@@ -90,24 +90,24 @@ namespace QuestingBots.Models.Questing
         public bool IsEFTQuest => Template != null;
         
         // Return all objectives in the quest
-        public ReadOnlyCollection<QuestObjective> AllObjectives => new ReadOnlyCollection<QuestObjective>(objectives);
+        public ReadOnlyCollection<BotQuestObjective> AllObjectives => new ReadOnlyCollection<BotQuestObjective>(objectives);
         public int NumberOfObjectives => AllObjectives.Count;
 
         // Return all objectives in the quest that have valid positions for their first step
-        public IEnumerable<QuestObjective> ValidObjectives => AllObjectives.Where(o => o.GetFirstStepPosition() != null);
+        public IEnumerable<BotQuestObjective> ValidObjectives => AllObjectives.Where(o => o.GetFirstStepPosition() != null);
         public int NumberOfValidObjectives => ValidObjectives.Count();
 
-        public Quest()
+        public BotQuest()
         {
 
         }
 
-        public Quest(string _name) : this()
+        public BotQuest(string _name) : this()
         {
             name = _name;
         }
 
-        public Quest(SptRawQuestClass template) : this()
+        public BotQuest(SptRawQuestClass template) : this()
         {
             Template = template;
         }
@@ -134,7 +134,7 @@ namespace QuestingBots.Models.Questing
 
         public void Clear()
         {
-            objectives = new QuestObjective[0];
+            objectives = new BotQuestObjective[0];
         }
 
         public IList<Vector3> GetWaypointPositions()
@@ -204,14 +204,14 @@ namespace QuestingBots.Models.Questing
             return canAssign;
         }
 
-        public void AddObjective(QuestObjective objective)
+        public void AddObjective(BotQuestObjective objective)
         {
             objective.UpdateQuestObjectiveStepNumbers();
 
             objectives = objectives.Append(objective).ToArray();
         }
 
-        public bool TryRemoveObjective(QuestObjective objective)
+        public bool TryRemoveObjective(BotQuestObjective objective)
         {
             if (objectives.Length == 0)
             {
@@ -224,31 +224,31 @@ namespace QuestingBots.Models.Questing
             return startingLength == objectives.Length + 1;
         }
 
-        public QuestObjective GetObjectiveForZoneID(string zoneId)
+        public BotQuestObjective GetObjectiveForZoneID(string zoneId)
         {
-            Func<QuestZoneObjective, bool> matchTest = o => o?.ZoneID == zoneId;
+            Func<BotQuestZoneObjective, bool> matchTest = o => o?.ZoneID == zoneId;
             return GetObjective(matchTest);
         }
 
-        public QuestObjective GetObjectiveForLootItem(LootItem item)
+        public BotQuestObjective GetObjectiveForLootItem(LootItem item)
         {
-            Func<QuestItemObjective, bool> matchTest = o => o.Item?.TemplateId == item.TemplateId;
+            Func<BotQuestItemObjective, bool> matchTest = o => o.Item?.TemplateId == item.TemplateId;
             return GetObjective(matchTest);
         }
 
-        public QuestObjective GetObjectiveForLootItem(string templateID)
+        public BotQuestObjective GetObjectiveForLootItem(string templateID)
         {
-            Func<QuestItemObjective, bool> matchTest = o => o.Item?.TemplateId == templateID;
+            Func<BotQuestItemObjective, bool> matchTest = o => o.Item?.TemplateId == templateID;
             return GetObjective(matchTest);
         }
 
-        public QuestObjective GetObjectiveForSpawnPoint(SpawnPointParams spawnPoint)
+        public BotQuestObjective GetObjectiveForSpawnPoint(SpawnPointParams spawnPoint)
         {
-            Func<QuestSpawnPointObjective, bool> matchTest = o => o.SpawnPoint?.Id == spawnPoint.Id;
+            Func<BotQuestSpawnPointObjective, bool> matchTest = o => o.SpawnPoint?.Id == spawnPoint.Id;
             return GetObjective(matchTest);
         }
 
-        private QuestObjective GetObjective<T>(Func<T, bool> matchTestFunc) where T : QuestObjective
+        private BotQuestObjective GetObjective<T>(Func<T, bool> matchTestFunc) where T : BotQuestObjective
         {
             IEnumerable<T> matchingObjectives = objectives
                 .OfType<T>()

--- a/Client/Models/Questing/BotQuest.cs
+++ b/Client/Models/Questing/BotQuest.cs
@@ -1,17 +1,18 @@
-﻿using System;
+﻿using Comfort.Common;
+using EFT;
+using EFT.Game.Spawning;
+using EFT.Interactive;
+using EFT.Quests;
+using Newtonsoft.Json;
+using QuestingBots.Helpers;
+using QuestingBots.Utils;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Comfort.Common;
-using EFT;
-using EFT.Game.Spawning;
-using EFT.Interactive;
-using Newtonsoft.Json;
-using QuestingBots.Helpers;
-using QuestingBots.Utils;
 using UnityEngine;
 
 namespace QuestingBots.Models.Questing
@@ -93,10 +94,6 @@ namespace QuestingBots.Models.Questing
         public ReadOnlyCollection<BotQuestObjective> AllObjectives => new ReadOnlyCollection<BotQuestObjective>(objectives);
         public int NumberOfObjectives => AllObjectives.Count;
 
-        // Return all objectives in the quest that have valid positions for their first step
-        public IEnumerable<BotQuestObjective> ValidObjectives => AllObjectives.Where(o => o.GetFirstStepPosition() != null);
-        public int NumberOfValidObjectives => ValidObjectives.Count();
-
         public BotQuest()
         {
 
@@ -137,6 +134,22 @@ namespace QuestingBots.Models.Questing
             objectives = new BotQuestObjective[0];
         }
 
+        // Return all objectives in the quest that have valid positions for their first step
+        public IEnumerable<BotQuestObjective> GetValidObjectives()
+        {
+            foreach (BotQuestObjective objective in objectives)
+            {
+                if (objective.GetFirstStepPosition() == null)
+                {
+                    continue;
+                }
+
+                yield return objective;
+            }
+        }
+
+        public int NumberOfValidObjectives() => GetValidObjectives().Count();
+
         public IList<Vector3> GetWaypointPositions()
         {
             if (waypointPositions != null)
@@ -173,13 +186,6 @@ namespace QuestingBots.Models.Questing
 
         public bool CanAssignBot(BotOwner bot)
         {
-            if (!RaidHelpers.HasRaidStarted())
-            {
-                return false;
-            }
-
-            float raidTime = RaidHelpers.GetRaidElapsedSeconds();
-
             if (AlarmQuest && !Singleton<GameWorld>.Instance.GetComponent<Components.LocationData>().AlarmState)
             {
                 return false;
@@ -195,6 +201,7 @@ namespace QuestingBots.Models.Questing
                 return false;
             }
 
+            float raidTime = RaidHelpers.GetRaidElapsedSeconds();
             bool canAssign = canAssignForBotType(bot)
                 && ((bot.Profile.Info.Level >= MinLevel) || !Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuestingRequirements.ExcludeBotsByLevel)
                 && ((bot.Profile.Info.Level <= MaxLevel) || !Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.BotQuestingRequirements.ExcludeBotsByLevel)
@@ -269,7 +276,7 @@ namespace QuestingBots.Models.Questing
 
         private bool isSwitchInCorrectPosition(string switchID, bool mustBeOpen)
         {
-            EFT.Interactive.Switch requiredSwitch = Singleton<GameWorld>.Instance.GetComponent<Components.LocationData>().FindSwitch(switchID);
+            EFT.Interactive.Switch? requiredSwitch = Singleton<GameWorld>.Instance.GetComponent<Components.LocationData>().FindSwitch(switchID);
             if (requiredSwitch == null)
             {
                 return true;

--- a/Client/Models/Questing/BotQuestItemObjective.cs
+++ b/Client/Models/Questing/BotQuestItemObjective.cs
@@ -9,18 +9,18 @@ using UnityEngine;
 
 namespace QuestingBots.Models.Questing
 {
-    public class QuestItemObjective : QuestObjective
+    public class BotQuestItemObjective : BotQuestObjective
     {
         public LootItem Item { get; set; } = null!;
 
         private string ItemName = null!;
 
-        public QuestItemObjective() : base()
+        public BotQuestItemObjective() : base()
         {
 
         }
 
-        public QuestItemObjective(LootItem item, Vector3 position) : base(position)
+        public BotQuestItemObjective(LootItem item, Vector3 position) : base(position)
         {
             Item = item;
             ItemName = Item.Item.LocalizedName();

--- a/Client/Models/Questing/BotQuestItemObjective.cs
+++ b/Client/Models/Questing/BotQuestItemObjective.cs
@@ -26,12 +26,6 @@ namespace QuestingBots.Models.Questing
             ItemName = Item.Item.LocalizedName();
         }
 
-        public override void Clear()
-        {
-            Item = null!;
-            base.Clear();
-        }
-
         public override string ToString()
         {
             if (Item != null)

--- a/Client/Models/Questing/BotQuestObjective.cs
+++ b/Client/Models/Questing/BotQuestObjective.cs
@@ -20,7 +20,7 @@ namespace QuestingBots.Models.Questing
         Inhibit = 2,
     }
 
-    public class QuestObjective
+    public class BotQuestObjective
     {
         [JsonProperty("repeatable")]
         public bool IsRepeatable { get; set; } = false;
@@ -54,30 +54,30 @@ namespace QuestingBots.Models.Questing
         private string name = "Unnamed Quest Objective";
 
         [JsonProperty("steps")]
-        private QuestObjectiveStep[] questObjectiveSteps = new QuestObjectiveStep[0];
+        private BotQuestObjectiveStep[] questObjectiveSteps = new BotQuestObjectiveStep[0];
 
         public string Name => name;
-        public ReadOnlyCollection<QuestObjectiveStep> AllSteps => new ReadOnlyCollection<QuestObjectiveStep>(questObjectiveSteps);
+        public ReadOnlyCollection<BotQuestObjectiveStep> AllSteps => new ReadOnlyCollection<BotQuestObjectiveStep>(questObjectiveSteps);
         public int StepCount => questObjectiveSteps.Length;
 
-        public QuestObjective()
+        public BotQuestObjective()
         {
 
         }
 
-        public QuestObjective(QuestObjectiveStep[] steps) : this()
+        public BotQuestObjective(BotQuestObjectiveStep[] steps) : this()
         {
             questObjectiveSteps = steps;
         }
 
-        public QuestObjective(QuestObjectiveStep step) : this()
+        public BotQuestObjective(BotQuestObjectiveStep step) : this()
         {
-            questObjectiveSteps = new QuestObjectiveStep[1] { step };
+            questObjectiveSteps = new BotQuestObjectiveStep[1] { step };
         }
 
-        public QuestObjective(Vector3 position) : this()
+        public BotQuestObjective(Vector3 position) : this()
         {
-            questObjectiveSteps = new QuestObjectiveStep[1] { new QuestObjectiveStep(position) };
+            questObjectiveSteps = new BotQuestObjectiveStep[1] { new BotQuestObjectiveStep(position) };
         }
 
         public override string ToString()
@@ -88,7 +88,7 @@ namespace QuestingBots.Models.Questing
         public virtual void Clear()
         {
             // Steps should never be deleted because some of them are generated from EFT's quests
-            foreach (QuestObjectiveStep step in questObjectiveSteps)
+            foreach (BotQuestObjectiveStep step in questObjectiveSteps)
             {
                 step.SetPosition(null);
             }
@@ -96,10 +96,10 @@ namespace QuestingBots.Models.Questing
 
         public void DeleteAllSteps()
         {
-            questObjectiveSteps = new QuestObjectiveStep[0];
+            questObjectiveSteps = new BotQuestObjectiveStep[0];
         }
 
-        public void AddStep(QuestObjectiveStep step)
+        public void AddStep(BotQuestObjectiveStep step)
         {
             // Immediately plant items after reaching objective locations
             if ((step.ActionType == QuestAction.PlantItem) && (questObjectiveSteps.Length > 0))
@@ -139,7 +139,7 @@ namespace QuestingBots.Models.Questing
 
         public void SetAllPositions(Vector3 position)
         {
-            foreach (QuestObjectiveStep step in questObjectiveSteps)
+            foreach (BotQuestObjectiveStep step in questObjectiveSteps)
             {
                 step.SetPosition(position);
             }
@@ -164,7 +164,7 @@ namespace QuestingBots.Models.Questing
         {
             bool allSnapped = true;
 
-            foreach (QuestObjectiveStep step in questObjectiveSteps)
+            foreach (BotQuestObjectiveStep step in questObjectiveSteps)
             {
                 float maxNavMeshDistance = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.QuestGeneration.NavMeshSearchDistanceSpawn;
                 if (!step.TrySnapToNavMesh(maxNavMeshDistance))
@@ -181,7 +181,7 @@ namespace QuestingBots.Models.Questing
         {
             bool allFound = true;
 
-            foreach (QuestObjectiveStep step in questObjectiveSteps)
+            foreach (BotQuestObjectiveStep step in questObjectiveSteps)
             {
                 if (!step.TryFindSwitch())
                 {
@@ -222,7 +222,7 @@ namespace QuestingBots.Models.Questing
             return true;
         }
 
-        public QuestObjectiveStep GetNextObjectiveStep(QuestObjectiveStep currentStep, bool allowReset = false)
+        public BotQuestObjectiveStep GetNextObjectiveStep(BotQuestObjectiveStep currentStep, bool allowReset = false)
         {
             if (!allowReset && (currentStep == null))
             {
@@ -230,7 +230,7 @@ namespace QuestingBots.Models.Questing
             }
 
             int currentStepNumber = currentStep?.StepNumber ?? 0;
-            IEnumerable<QuestObjectiveStep> nextStep = questObjectiveSteps.Where(s => s.StepNumber == currentStepNumber + 1);
+            IEnumerable<BotQuestObjectiveStep> nextStep = questObjectiveSteps.Where(s => s.StepNumber == currentStepNumber + 1);
 
             if (nextStep.Any())
             {

--- a/Client/Models/Questing/BotQuestObjective.cs
+++ b/Client/Models/Questing/BotQuestObjective.cs
@@ -85,15 +85,6 @@ namespace QuestingBots.Models.Questing
             return name;
         }
 
-        public virtual void Clear()
-        {
-            // Steps should never be deleted because some of them are generated from EFT's quests
-            foreach (BotQuestObjectiveStep step in questObjectiveSteps)
-            {
-                step.SetPosition(null);
-            }
-        }
-
         public void DeleteAllSteps()
         {
             questObjectiveSteps = new BotQuestObjectiveStep[0];
@@ -124,25 +115,7 @@ namespace QuestingBots.Models.Questing
                 return null;
             }
 
-            return questObjectiveSteps[0].GetPosition();
-        }
-
-        public void SetFirstPosition(Vector3 position)
-        {
-            if (questObjectiveSteps.Length == 0)
-            {
-                throw new InvalidOperationException("There are no steps in the objective.");
-            }
-
-            questObjectiveSteps[0].SetPosition(position);
-        }
-
-        public void SetAllPositions(Vector3 position)
-        {
-            foreach (BotQuestObjectiveStep step in questObjectiveSteps)
-            {
-                step.SetPosition(position);
-            }
+            return questObjectiveSteps[0].Position;
         }
 
         public void SetFirstWaitTimeAfterCompleting(float time)
@@ -157,7 +130,10 @@ namespace QuestingBots.Models.Questing
 
         public IEnumerable<Vector3?> GetAllPositions()
         {
-            return questObjectiveSteps.Select(step => step.GetPosition());
+            foreach (BotQuestObjectiveStep step in questObjectiveSteps)
+            {
+                yield return step.Position;
+            }
         }
 
         public bool TrySnapAllStepPositionsToNavMesh()
@@ -170,7 +146,7 @@ namespace QuestingBots.Models.Questing
                 if (!step.TrySnapToNavMesh(maxNavMeshDistance))
                 {
                     allSnapped = false;
-                    Singleton<LoggingUtil>.Instance.LogError("Unable to snap position " + (step.GetPosition()?.ToString() ?? "???") + " to NavMesh for quest objective " + ToString());
+                    Singleton<LoggingUtil>.Instance.LogError("Unable to snap position " + (step.Position?.ToString() ?? "???") + " to NavMesh for quest objective " + ToString());
                 }
             }
 
@@ -201,7 +177,7 @@ namespace QuestingBots.Models.Questing
                 return false;
             }
 
-            Vector3? position = questObjectiveSteps[0].GetPosition();
+            Vector3? position = questObjectiveSteps[0].Position;
             if (!position.HasValue)
             {
                 return false;

--- a/Client/Models/Questing/BotQuestObjective.cs
+++ b/Client/Models/Questing/BotQuestObjective.cs
@@ -198,11 +198,11 @@ namespace QuestingBots.Models.Questing
             return true;
         }
 
-        public BotQuestObjectiveStep GetNextObjectiveStep(BotQuestObjectiveStep currentStep, bool allowReset = false)
+        public BotQuestObjectiveStep? GetNextObjectiveStep(BotQuestObjectiveStep currentStep, bool allowReset = false)
         {
             if (!allowReset && (currentStep == null))
             {
-                return null!;
+                return null;
             }
 
             int currentStepNumber = currentStep?.StepNumber ?? 0;
@@ -213,7 +213,7 @@ namespace QuestingBots.Models.Questing
                 return nextStep.First();
             }
 
-            return null!;
+            return null;
         }
 
         public void UpdateQuestObjectiveStepNumbers()

--- a/Client/Models/Questing/BotQuestObjectiveStep.cs
+++ b/Client/Models/Questing/BotQuestObjectiveStep.cs
@@ -29,7 +29,7 @@ namespace QuestingBots.Models.Questing
         OpenNearbyDoors
     }
 
-    public class QuestObjectiveStep
+    public class BotQuestObjectiveStep
     {
         [JsonProperty("waitTimeAfterCompleting")]
         public double WaitTimeAfterCompleting { get; set; } = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.DefaultWaitTimeAfterObjectiveCompletion;
@@ -71,27 +71,27 @@ namespace QuestingBots.Models.Questing
         [JsonIgnore]
         public WorldInteractiveObject InteractiveObject { get; set; } = null!;
 
-        public QuestObjectiveStep()
+        public BotQuestObjectiveStep()
         {
 
         }
 
-        public QuestObjectiveStep(SerializableVector3 position) : this()
+        public BotQuestObjectiveStep(SerializableVector3 position) : this()
         {
             SerializablePosition = position;
         }
 
-        public QuestObjectiveStep(Vector3 position) : this()
+        public BotQuestObjectiveStep(Vector3 position) : this()
         {
             SerializablePosition = position.ToSerializableVector3();
         }
 
-        public QuestObjectiveStep(Vector3 position, QuestAction actionType) : this(position)
+        public BotQuestObjectiveStep(Vector3 position, QuestAction actionType) : this(position)
         {
             ActionType = actionType;
         }
 
-        public QuestObjectiveStep(Vector3 position, QuestAction actionType, Configuration.MinMaxConfig minElapsedTime) : this(position, actionType)
+        public BotQuestObjectiveStep(Vector3 position, QuestAction actionType, Configuration.MinMaxConfig minElapsedTime) : this(position, actionType)
         {
             MinElapsedTime = minElapsedTime;
         }

--- a/Client/Models/Questing/BotQuestObjectiveStep.cs
+++ b/Client/Models/Questing/BotQuestObjectiveStep.cs
@@ -35,13 +35,13 @@ namespace QuestingBots.Models.Questing
         public double WaitTimeAfterCompleting { get; set; } = Singleton<ConfigUtil>.Instance.CurrentConfig.Questing.DefaultWaitTimeAfterObjectiveCompletion;
 
         [JsonProperty("position")]
-        public SerializableVector3 SerializablePosition { get; set; } = null!;
+        public SerializableVector3? SerializablePosition { get; set; } = null;
 
         [JsonProperty("lookToPosition")]
-        public SerializableVector3 SerializableLookToPosition { get; set; } = null!;
+        public SerializableVector3? SerializableLookToPosition { get; set; } = null;
 
         [JsonProperty("targetPosition")]
-        public SerializableVector3 SerializableTargetPosition { get; set; } = null!;
+        public SerializableVector3? SerializableTargetPosition { get; set; } = null;
 
         [JsonProperty("stepType")]
         [JsonConverter(typeof(StringEnumConverter))]
@@ -69,7 +69,65 @@ namespace QuestingBots.Models.Questing
         public int? StepNumber { get; set; } = null;
 
         [JsonIgnore]
-        public WorldInteractiveObject InteractiveObject { get; set; } = null!;
+        public WorldInteractiveObject? InteractiveObject { get; set; } = null;
+
+        [JsonIgnore]
+        private Vector3? _position = null;
+        public Vector3? Position
+        {
+            get
+            {
+                if (_position == null)
+                {
+                    if ((SerializablePosition != null) && !SerializablePosition.HasNaNComponent())
+                    {
+                        _position = SerializablePosition.ToUnityVector3();
+                    }
+                    else
+                    {
+                        Singleton<LoggingUtil>.Instance.LogWarning("SerializablePosition is invalid for step: " + SerializablePosition?.ToString() ?? " [NULL]");
+                    }
+                }
+
+                return _position;
+            }
+        }
+
+        [JsonIgnore]
+        private Vector3? _lookToPosition = null;
+        public Vector3? LookToPosition
+        {
+            get
+            {
+                if (_lookToPosition == null)
+                {
+                    if ((SerializableLookToPosition != null) && !SerializableLookToPosition.HasNaNComponent())
+                    {
+                        _lookToPosition = SerializableLookToPosition.ToUnityVector3();
+                    }
+                }
+
+                return _lookToPosition;
+            }
+        }
+
+        [JsonIgnore]
+        private Vector3? _targetPosition = null;
+        public Vector3? TargetPosition
+        {
+            get
+            {
+                if (_targetPosition == null)
+                {
+                    if ((SerializableTargetPosition != null) && !SerializableTargetPosition.HasNaNComponent())
+                    {
+                        _targetPosition = SerializableTargetPosition.ToUnityVector3();
+                    }
+                }
+
+                return _targetPosition;
+            }
+        }
 
         public BotQuestObjectiveStep()
         {
@@ -101,47 +159,6 @@ namespace QuestingBots.Models.Questing
             return "Step " + (StepNumber.HasValue ? ("#" + StepNumber.Value.ToString()) : "???");
         }
 
-        public Vector3? GetPosition()
-        {
-            if ((SerializablePosition == null) || SerializablePosition.Any(float.NaN))
-            {
-                return null;
-            }
-
-            return SerializablePosition.ToUnityVector3();
-        }
-
-        public Vector3? GetLookToPosition()
-        {
-            if ((SerializableLookToPosition == null) || SerializableLookToPosition.Any(float.NaN))
-            {
-                return null;
-            }
-
-            return SerializableLookToPosition.ToUnityVector3();
-        }
-
-        public Vector3? GetTargetPosition()
-        {
-            if ((SerializableTargetPosition == null) || SerializableTargetPosition.Any(float.NaN))
-            {
-                return null;
-            }
-
-            return SerializableTargetPosition.ToUnityVector3();
-        }
-
-        public void SetPosition(Vector3? position)
-        {
-            if (!position.HasValue)
-            {
-                SerializablePosition = null!;
-                return;
-            }
-
-            SerializablePosition = position.Value.ToSerializableVector3();
-        }
-
         public bool TrySnapToNavMesh(float maxDistance)
         {
             if (SerializablePosition == null)
@@ -157,6 +174,7 @@ namespace QuestingBots.Models.Questing
                 return false;
             }
 
+            _position = null;
             SerializablePosition = navMeshPosition.Value.ToSerializableVector3();
             return true;
         }

--- a/Client/Models/Questing/BotQuestSpawnPointObjective.cs
+++ b/Client/Models/Questing/BotQuestSpawnPointObjective.cs
@@ -8,16 +8,16 @@ using UnityEngine;
 
 namespace QuestingBots.Models.Questing
 {
-    public class QuestSpawnPointObjective : QuestObjective
+    public class BotQuestSpawnPointObjective : BotQuestObjective
     {
         public SpawnPointParams? SpawnPoint { get; set; } = null;
 
-        public QuestSpawnPointObjective() : base()
+        public BotQuestSpawnPointObjective() : base()
         {
 
         }
 
-        public QuestSpawnPointObjective(SpawnPointParams spawnPoint, Vector3 position) : base(position)
+        public BotQuestSpawnPointObjective(SpawnPointParams spawnPoint, Vector3 position) : base(position)
         {
             SpawnPoint = spawnPoint;
         }

--- a/Client/Models/Questing/BotQuestSpawnPointObjective.cs
+++ b/Client/Models/Questing/BotQuestSpawnPointObjective.cs
@@ -22,12 +22,6 @@ namespace QuestingBots.Models.Questing
             SpawnPoint = spawnPoint;
         }
 
-        public override void Clear()
-        {
-            SpawnPoint = null;
-            base.Clear();
-        }
-
         public override string ToString()
         {
             if (SpawnPoint.HasValue)

--- a/Client/Models/Questing/BotQuestZoneObjective.cs
+++ b/Client/Models/Questing/BotQuestZoneObjective.cs
@@ -7,21 +7,21 @@ using UnityEngine;
 
 namespace QuestingBots.Models.Questing
 {
-    public class QuestZoneObjective : QuestObjective
+    public class BotQuestZoneObjective : BotQuestObjective
     {
         public string ZoneID { get; set; } = null!;
 
-        public QuestZoneObjective() : base()
+        public BotQuestZoneObjective() : base()
         {
 
         }
 
-        public QuestZoneObjective(string zoneID) : this()
+        public BotQuestZoneObjective(string zoneID) : this()
         {
             ZoneID = zoneID;
         }
 
-        public QuestZoneObjective(string zoneID, Vector3 position) : base(position)
+        public BotQuestZoneObjective(string zoneID, Vector3 position) : base(position)
         {
             ZoneID = zoneID;
         }

--- a/Client/Models/Questing/BotQuestZoneObjective.cs
+++ b/Client/Models/Questing/BotQuestZoneObjective.cs
@@ -26,12 +26,6 @@ namespace QuestingBots.Models.Questing
             ZoneID = zoneID;
         }
 
-        public override void Clear()
-        {
-            ZoneID = null!;
-            base.Clear();
-        }
-
         public override string ToString()
         {
             if (ZoneID != null)

--- a/Client/Models/Questing/CompletedBotJobAssignmentCreationJob.cs
+++ b/Client/Models/Questing/CompletedBotJobAssignmentCreationJob.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+
+namespace QuestingBots.Models.Questing
+{
+    public class CompletedBotJobAssignmentCreationJob : IBotJobAssignmentCreationJob
+    {
+        public bool IsCreatingAnAssignment => false;
+        public bool NewAssignmentReady => true;
+
+        private BotJobAssignment? _assignmentCreationResult;
+        public BotJobAssignment? AssignmentCreationResult => _assignmentCreationResult;
+
+        public CompletedBotJobAssignmentCreationJob(BotJobAssignment? botJobAssignment)
+        {
+            _assignmentCreationResult = botJobAssignment;
+        }
+
+        public IEnumerator CreateNewBotJobAssignment()
+        {
+            yield break;
+        }
+    }
+}

--- a/Client/Models/Questing/IBotJobAssignmentCreationJob.cs
+++ b/Client/Models/Questing/IBotJobAssignmentCreationJob.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+
+namespace QuestingBots.Models.Questing
+{
+    public interface IBotJobAssignmentCreationJob
+    {
+        bool IsCreatingAnAssignment { get; }
+        bool NewAssignmentReady { get; }
+        BotJobAssignment? AssignmentCreationResult { get; }
+
+        IEnumerator CreateNewBotJobAssignment();
+    }
+}

--- a/Client/Models/Questing/JobAssignment.cs
+++ b/Client/Models/Questing/JobAssignment.cs
@@ -9,19 +9,19 @@ namespace QuestingBots.Models.Questing
 {
     public class JobAssignment : ICloneable
     {
-        public Quest QuestAssignment { get; protected set; } = null!;
-        public QuestObjective QuestObjectiveAssignment { get; protected set; } = null!;
-        public QuestObjectiveStep QuestObjectiveStepAssignment { get; protected set; } = null!;
+        public BotQuest QuestAssignment { get; protected set; } = null!;
+        public BotQuestObjective QuestObjectiveAssignment { get; protected set; } = null!;
+        public BotQuestObjectiveStep QuestObjectiveStepAssignment { get; protected set; } = null!;
 
         public Vector3? Position => QuestObjectiveStepAssignment?.GetPosition();
-        public bool IsSpawnSearchQuest => QuestObjectiveAssignment is QuestSpawnPointObjective;
+        public bool IsSpawnSearchQuest => QuestObjectiveAssignment is BotQuestSpawnPointObjective;
 
         public JobAssignment()
         {
 
         }
 
-        public JobAssignment(Quest _quest, QuestObjective _objective, QuestObjectiveStep _step) : this()
+        public JobAssignment(BotQuest _quest, BotQuestObjective _objective, BotQuestObjectiveStep _step) : this()
         {
             QuestAssignment = _quest;
             QuestObjectiveAssignment = _objective;

--- a/Client/Models/Questing/JobAssignment.cs
+++ b/Client/Models/Questing/JobAssignment.cs
@@ -13,7 +13,7 @@ namespace QuestingBots.Models.Questing
         public BotQuestObjective QuestObjectiveAssignment { get; protected set; } = null!;
         public BotQuestObjectiveStep QuestObjectiveStepAssignment { get; protected set; } = null!;
 
-        public Vector3? Position => QuestObjectiveStepAssignment?.GetPosition();
+        public Vector3? Position => QuestObjectiveStepAssignment?.Position;
         public bool IsSpawnSearchQuest => QuestObjectiveAssignment is BotQuestSpawnPointObjective;
 
         public JobAssignment()

--- a/Client/Patches/BotOwnerBrainActivatePatch.cs
+++ b/Client/Patches/BotOwnerBrainActivatePatch.cs
@@ -1,13 +1,8 @@
-﻿using Comfort.Common;
-using EFT;
-using EFT.Ballistics;
-using QuestingBots.Components.Spawning;
-using QuestingBots.Controllers;
-using QuestingBots.Helpers;
-using QuestingBots.Utils;
-using QuestingBots.Utils.Benchmarking;
+﻿using EFT;
+using QuestingBots.Components;
 using SPT.Reflection.Patching;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -23,127 +18,10 @@ namespace QuestingBots.Patches
             return typeof(BotOwner).GetMethod("method_10", BindingFlags.Public | BindingFlags.Instance);
         }
 
-        [Benchmark]
         [PatchPostfix]
         protected static void PatchPostfix(BotOwner __instance)
         {
-            registerBot(__instance);
-            registerBotComponents(__instance);
-            adjustEftBotCounts(__instance);
-            updateBotHostilities(__instance);
-
-            // Fix for bots getting stuck in Standby when enemy PMC's are near them
-            __instance.StandBy.CanDoStandBy = false;
-        }
-
-        [Benchmark]
-        private static void registerBot(BotOwner __instance)
-        {
-            string roleName = __instance.Profile.Info.Settings.Role.ToString();
-            Singleton<LoggingUtil>.Instance.LogInfo("Initial spawn type for bot " + __instance.GetText() + ": " + roleName);
-
-            if (__instance.WillBeAPMC())
-            {
-                Controllers.BotRegistrationManager.RegisterPMC(__instance);
-            }
-            else if (__instance.WillBeABoss())
-            {
-                Controllers.BotRegistrationManager.RegisterBoss(__instance);
-            }
-
-            Controllers.BotRegistrationManager.WriteMessageForNewBotSpawn(__instance);
-
-            if (__instance.IsARegisteredPMC() || __instance.WillBeAPlayerScav())
-            {
-                registerBotAsHumanPlayer(__instance);
-            }
-        }
-
-        [Benchmark]
-        private static void registerBotComponents(BotOwner __instance)
-        {
-            BotLogic.HiveMind.BotHiveMindMonitor.RegisterBot(__instance);
-            Singleton<GameWorld>.Instance.GetComponent<Components.DebugData>().RegisterBot(__instance);
-        }
-
-        [Benchmark]
-        private static void adjustEftBotCounts(BotOwner __instance)
-        {
-            if (BotGenerator.GetAllGeneratedBotProfileIDs().Contains(__instance.Profile.Id))
-            {
-                reduceBotCounts(__instance);
-            }
-        }
-
-        [Benchmark]
-        private static void updateBotHostilities(BotOwner __instance)
-        {
-            if (shouldMakeBotGroupHostileTowardAllBosses(__instance))
-            {
-                Controllers.BotRegistrationManager.MakeBotGroupHostileTowardAllBosses(__instance);
-            }
-        }
-
-        [Benchmark]
-        private static void registerBotAsHumanPlayer(BotOwner __instance)
-        {
-            if (!Singleton<ConfigUtil>.Instance.CurrentConfig.BotSpawns.Enabled)
-            {
-                return;
-            }
-
-            BotSpawner botSpawnerClass = Singleton<IBotGame>.Instance.BotsController.BotSpawner;
-
-            botSpawnerClass.AddPlayer(__instance.GetPlayer());
-            __instance.GetPlayer().OnPlayerDead += deletePlayer;
-        }
-
-        private static void deletePlayer(Player player, IPlayer lastAgressor, DamageInfo damage, EBodyPart part)
-        {
-            BotSpawner botSpawnerClass = Singleton<IBotGame>.Instance.BotsController.BotSpawner;
-
-            try
-            {
-                botSpawnerClass.DeletePlayer(player.GetPlayer());
-            }
-            catch (Exception ex)
-            {
-                Singleton<LoggingUtil>.Instance.LogError("Could not delete player " + player.GetText() + ": " + ex.Message);
-                Singleton<LoggingUtil>.Instance.LogError(ex.StackTrace);
-            }
-        }
-
-        private static bool shouldMakeBotGroupHostileTowardAllBosses(BotOwner bot)
-        {
-            BotType botType = Controllers.BotRegistrationManager.GetBotType(bot);
-
-            float chance = Singleton<ConfigUtil>.Instance.CurrentConfig.ChanceOfBeingHostileTowardBosses.GetValue(botType) ?? 0;
-
-            System.Random random = new System.Random();
-            if (random.Next(1, 100) <= chance)
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        private static void reduceBotCounts(BotOwner bot)
-        {
-            Singleton<LoggingUtil>.Instance.LogDebug("Adjusting EFT bot counts for " + bot.GetText() + "...");
-
-            BotSpawner botSpawnerClass = Singleton<IBotGame>.Instance.BotsController.BotSpawner;
-
-            if (bot.Profile.Info.Settings.IsFollower())
-            {
-                botSpawnerClass._followersBotsCount--;
-            }
-            else if (bot.Profile.Info.Settings.IsBoss())
-            {
-                botSpawnerClass._bossBotsCount--;
-            }
-
-            botSpawnerClass._allBotsCount--;
+            BotIdentityData.GetBotIdentityData(__instance);
         }
     }
 }

--- a/Client/Patches/BotsControllerStopPatch.cs
+++ b/Client/Patches/BotsControllerStopPatch.cs
@@ -36,9 +36,6 @@ namespace QuestingBots.Patches
                 botGenerator.enabled = false;
             }
 
-            // Clear cache
-            Components.Spawning.BotGenerator.Clear();
-
             // Write all log files
             if (Singleton<GameWorld>.Instance.GetComponent<Components.BotQuestBuilder>().HaveQuestsBeenBuilt)
             {

--- a/Client/Patches/BotsControllerStopPatch.cs
+++ b/Client/Patches/BotsControllerStopPatch.cs
@@ -41,8 +41,8 @@ namespace QuestingBots.Patches
             {
                 long timestamp = DateTime.Now.ToFileTimeUtc();
 
-                BotJobAssignmentFactory.WriteQuestLogFile(timestamp);
-                BotJobAssignmentFactory.WriteBotJobAssignmentLogFile(timestamp);
+                BotJobAssignmentController.WriteQuestLogFile(timestamp);
+                BotJobAssignmentController.WriteBotJobAssignmentLogFile(timestamp);
 
 #if DEBUG
                 BenchmarkService.LogAllBenchmarksAndReset(timestamp);
@@ -50,7 +50,7 @@ namespace QuestingBots.Patches
             }
 
             // Erase all bot and bot-assignment tracking data
-            BotJobAssignmentFactory.Clear();
+            BotJobAssignmentController.Clear();
             Controllers.BotRegistrationManager.Clear();
 
             // Not really needed since BotHiveMindMonitor is attached to GameWorld, but this may reduce CPU load a tad

--- a/Client/Patches/DebugPatches/ProcessSourceOcclusionPatch.cs
+++ b/Client/Patches/DebugPatches/ProcessSourceOcclusionPatch.cs
@@ -30,8 +30,7 @@ namespace QuestingBots.Patches.DebugPatches
         {
             if (source == null)
             {
-                Singleton<LoggingUtil>.Instance.LogWarning("Skipping ProcessSourceOcclusion with null sound for " + player.GetText() + "...");
-
+                //Singleton<LoggingUtil>.Instance.LogWarning("Skipping ProcessSourceOcclusion with null sound for " + player.GetText() + "...");
                 return false;
             }
 

--- a/Client/Patches/DisableLocalAvoidancePatch.cs
+++ b/Client/Patches/DisableLocalAvoidancePatch.cs
@@ -1,6 +1,5 @@
 ﻿using Comfort.Common;
 using EFT;
-using HarmonyLib;
 using QuestingBots.Controllers;
 using QuestingBots.Utils;
 using SPT.Reflection.Patching;

--- a/Client/Patches/IsFollowerSuitableForBossPatch.cs
+++ b/Client/Patches/IsFollowerSuitableForBossPatch.cs
@@ -1,14 +1,15 @@
-﻿using System;
+﻿using Comfort.Common;
+using EFT;
+using QuestingBots.Components.Spawning;
+using QuestingBots.Helpers;
+using QuestingBots.Utils;
+using SPT.Reflection.Patching;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using SPT.Reflection.Patching;
-using EFT;
-using QuestingBots.Helpers;
-using Comfort.Common;
-using QuestingBots.Utils;
 
 namespace QuestingBots.Patches
 {
@@ -30,14 +31,16 @@ namespace QuestingBots.Patches
                 return true;
             }
 
+            BotGenerationManager botGenerationManager = Singleton<GameWorld>.Instance.GetComponent<BotGenerationManager>();
+
             IReadOnlyCollection<Profile> bossGroupMemberProfiles = emptyProfileCollection;
-            if (Components.Spawning.BotGenerator.TryGetBotGroupFromAnyGenerator(__instance.Owner, out Models.BotSpawnInfo botSpawnInfo))
+            if (botGenerationManager.TryGetBotGroupFromAnyGenerator(__instance.Owner, out Models.BotSpawnInfo botSpawnInfo))
             {
                 bossGroupMemberProfiles = botSpawnInfo.GetGeneratedProfiles();
             }
 
             IReadOnlyCollection<Profile> offerGroupMemberProfiles = emptyProfileCollection;
-            if (Components.Spawning.BotGenerator.TryGetBotGroupFromAnyGenerator(offer, out botSpawnInfo))
+            if (botGenerationManager.TryGetBotGroupFromAnyGenerator(offer, out botSpawnInfo))
             {
                 offerGroupMemberProfiles = botSpawnInfo.GetGeneratedProfiles();
             }

--- a/Client/Patches/OnBeenKilledByAggressorPatch.cs
+++ b/Client/Patches/OnBeenKilledByAggressorPatch.cs
@@ -40,7 +40,7 @@ namespace QuestingBots.Patches
             Singleton<LoggingUtil>.Instance.LogInfo(message);
 
             // Make sure the bot doesn't have any active quests if it's dead
-            Controllers.BotJobAssignmentFactory.FailAllJobAssignmentsForBot(__instance.Profile.Id);
+            Controllers.BotJobAssignmentController.FailAllJobAssignmentsForBot(__instance.Profile.Id);
         }
     }
 }

--- a/Client/Patches/ReturnToPoolPatch.cs
+++ b/Client/Patches/ReturnToPoolPatch.cs
@@ -17,6 +17,7 @@ namespace QuestingBots.Patches
         protected static void PatchPrefix(GameObject gameObject)
         {
             TryDestroyComponent<Components.BotIdentityData>(gameObject);
+            TryDestroyComponent<Components.BotQuestSelector>(gameObject);
             TryDestroyComponent<Components.BotObjectiveManager>(gameObject);
             TryDestroyComponent<BotLogic.BotMonitor.BotMonitorController>(gameObject);
         }

--- a/Client/Patches/ReturnToPoolPatch.cs
+++ b/Client/Patches/ReturnToPoolPatch.cs
@@ -16,13 +16,16 @@ namespace QuestingBots.Patches
         [PatchPrefix]
         protected static void PatchPrefix(GameObject gameObject)
         {
-            if (gameObject.TryGetComponent<Components.BotObjectiveManager>(out var objectiveManager))
+            TryDestroyComponent<Components.BotIdentityData>(gameObject);
+            TryDestroyComponent<Components.BotObjectiveManager>(gameObject);
+            TryDestroyComponent<BotLogic.BotMonitor.BotMonitorController>(gameObject);
+        }
+
+        private static void TryDestroyComponent<T>(GameObject gameObject) where T: Component
+        {
+            if (gameObject.TryGetComponent<T>(out var component))
             {
-                UnityEngine.Object.Destroy(objectiveManager);
-            }
-            if (gameObject.TryGetComponent<BotLogic.BotMonitor.BotMonitorController>(out var botMonitorController))
-            {
-                UnityEngine.Object.Destroy(botMonitorController);
+                UnityEngine.Object.Destroy(component);
             }
         }
     }

--- a/Client/Patches/Spawning/ActivateBossesByWavePatch.cs
+++ b/Client/Patches/Spawning/ActivateBossesByWavePatch.cs
@@ -69,7 +69,7 @@ namespace QuestingBots.Patches.Spawning
                     BotRegistrationManager.ZeroWaveTotalBotCount -= botCount;
                     BotRegistrationManager.ZeroWaveTotalRogueCount -= botCount;
 
-                    Singleton<LoggingUtil>.Instance.LogWarning("Suppressing boss wave (" + botCount + " bots) or too many Rogues will be on the map");
+                    Singleton<LoggingUtil>.Instance.LogWarning("Suppressing " + bossWave.BossName + " boss wave (" + botCount + " bots) or too many Rogues will be on the map");
                     return true;
                 }
             }
@@ -80,7 +80,7 @@ namespace QuestingBots.Patches.Spawning
             {
                 BotRegistrationManager.ZeroWaveTotalBotCount -= botCount;
 
-                Singleton<LoggingUtil>.Instance.LogWarning("Suppressing boss wave (" + botCount + " bots) or too many bosses will be on the map");
+                Singleton<LoggingUtil>.Instance.LogWarning("Suppressing " + bossWave.BossName + " boss wave (" + botCount + " bots) or too many bosses will be on the map");
                 return true;
             }
 

--- a/Client/Patches/Spawning/AddEnemyPatch.cs
+++ b/Client/Patches/Spawning/AddEnemyPatch.cs
@@ -1,15 +1,16 @@
-﻿using System;
+﻿using Comfort.Common;
+using EFT;
+using QuestingBots.Components.Spawning;
+using QuestingBots.Utils;
+using SPT.Custom.CustomAI;
+using SPT.Reflection.Patching;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using SPT.Custom.CustomAI;
-using SPT.Reflection.Patching;
-using Comfort.Common;
-using EFT;
-using QuestingBots.Utils;
 
 namespace QuestingBots.Patches.Spawning
 {
@@ -50,9 +51,10 @@ namespace QuestingBots.Patches.Spawning
 
             // Check if the the bot group was created by this mod
             bool isGroupFromBotGenerator = false;
-            foreach (Components.Spawning.BotGenerator botGenerator in Singleton<GameWorld>.Instance.gameObject.GetComponents(typeof(Components.Spawning.BotGenerator)))
+            IEnumerable<string> allGeneratedBotProfileIds = Singleton<GameWorld>.Instance.GetComponent<BotGenerationManager>().GetAllGeneratedBotProfileIDs();
+            foreach (string id in allGeneratedBotProfileIds)
             {
-                if (botGenerator.GetBotGroups().Any(g => g.SpawnedBots.Any(b => groupMemberIDs.Contains(b.Profile.Id))))
+                if (groupMemberIDs.Contains(id))
                 {
                     isGroupFromBotGenerator = true;
                     break;

--- a/Client/Patches/Spawning/BotsGroupIsPlayerEnemyPatch.cs
+++ b/Client/Patches/Spawning/BotsGroupIsPlayerEnemyPatch.cs
@@ -71,7 +71,7 @@ namespace QuestingBots.Patches.Spawning
                 return true;
             }
 
-            if (BotGenerator.TryGetBotGroupFromAnyGenerator(__instance._initialBot, out Models.BotSpawnInfo botSpawnInfo))
+            if (Singleton<GameWorld>.Instance.GetComponent<BotGenerationManager>().TryGetBotGroupFromAnyGenerator(__instance._initialBot, out Models.BotSpawnInfo botSpawnInfo))
             {
                 if (botSpawnInfo.ContainsProfile(player.Profile))
                 {

--- a/Client/QuestingBotsExternal.cs
+++ b/Client/QuestingBotsExternal.cs
@@ -135,12 +135,8 @@ namespace QuestingBots
 
         private static BotJobAssignment? GetCurrentJobAssignmentForActiveBot(this BotOwner bot)
         {
-            if (!bot.IsActive())
-            {
-                return null;
-            }
-
-            BotJobAssignment? botJobAssignment = BotJobAssignmentFactory.GetCurrentJobAssignment(bot, false);
+            BotObjectiveManager? botObjectiveManager = bot.GetBotObjectiveManagerForActiveBot();
+            BotJobAssignment? botJobAssignment = botObjectiveManager?.QuestSelector?.GetCurrentJobAssignment(false);
             return botJobAssignment;
         }
 

--- a/Client/QuestingBotsExternal.cs
+++ b/Client/QuestingBotsExternal.cs
@@ -136,7 +136,7 @@ namespace QuestingBots
         private static BotJobAssignment? GetCurrentJobAssignmentForActiveBot(this BotOwner bot)
         {
             BotObjectiveManager? botObjectiveManager = bot.GetBotObjectiveManagerForActiveBot();
-            BotJobAssignment? botJobAssignment = botObjectiveManager?.QuestSelector?.GetCurrentJobAssignment(false);
+            BotJobAssignment? botJobAssignment = botObjectiveManager?.QuestSelector?.GetCurrentJobAssignment();
             return botJobAssignment;
         }
 

--- a/Client/QuestingBotsExternal.cs
+++ b/Client/QuestingBotsExternal.cs
@@ -136,7 +136,7 @@ namespace QuestingBots
         private static BotJobAssignment? GetCurrentJobAssignmentForActiveBot(this BotOwner bot)
         {
             BotObjectiveManager? botObjectiveManager = bot.GetBotObjectiveManagerForActiveBot();
-            BotJobAssignment? botJobAssignment = botObjectiveManager?.QuestSelector?.GetCurrentJobAssignment();
+            BotJobAssignment? botJobAssignment = botObjectiveManager?.CurrentAssignment;
             return botJobAssignment;
         }
 

--- a/Client/QuestingBotsExternal.cs
+++ b/Client/QuestingBotsExternal.cs
@@ -22,7 +22,7 @@ namespace QuestingBots
 
         public static IEnumerable<string[]> GetJobAssignmentHistoryCsvData(this BotOwner bot)
         {
-            IEnumerable<BotJobAssignment> allJobAssignments = bot.GetAllQuests();
+            IEnumerable<BotJobAssignment> allJobAssignments = bot.GetAllQuestAssignments();
             foreach (BotJobAssignment assignment in allJobAssignments)
             {
                 yield return new string[]

--- a/Client/Utils/ConfigUtil.cs
+++ b/Client/Utils/ConfigUtil.cs
@@ -128,9 +128,9 @@ namespace QuestingBots.Utils
             return _positions;
         }
 
-        public IEnumerable<Models.Questing.Quest> GetCustomQuests(string locationID)
+        public IEnumerable<Models.Questing.BotQuest> GetCustomQuests(string locationID)
         {
-            Models.Questing.Quest[] standardQuests = new Models.Questing.Quest[0];
+            Models.Questing.BotQuest[] standardQuests = new Models.Questing.BotQuest[0];
             string filename = Singleton<LoggingUtil>.Instance.LoggingPath + "..\\Quests\\Standard\\" + locationID + ".json";
             if (File.Exists(filename))
             {
@@ -148,7 +148,7 @@ namespace QuestingBots.Utils
                 }
             }
 
-            Models.Questing.Quest[] customQuests = new Models.Questing.Quest[0];
+            Models.Questing.BotQuest[] customQuests = new Models.Questing.BotQuest[0];
             filename = Singleton<LoggingUtil>.Instance.LoggingPath + "..\\Quests\\Custom\\" + locationID + ".json";
             if (File.Exists(filename))
             {

--- a/Server/Patches/GenerateBotWavePatch.cs
+++ b/Server/Patches/GenerateBotWavePatch.cs
@@ -7,6 +7,7 @@ using SPTarkov.Server.Core.Models.Eft.Bot;
 using SPTarkov.Server.Core.Models.Eft.Common.Tables;
 using SPTarkov.Server.Core.Services.Bot;
 using System.Collections;
+using System.Diagnostics;
 using System.Reflection;
 using System.Text.Json;
 
@@ -73,11 +74,9 @@ namespace QuestingBots.Patches
             }
         }
 
-        private static List<BotBase?> ConvertAllToPScav(IEnumerable<BotBase?> bots, int targetCount)
+        private static IEnumerable<BotBase?> ConvertAllToPScav(IEnumerable<BotBase?> bots, int targetCount)
         {
-            List<BotBase?> UpdatedBots = new List<BotBase?>();
             int convertedBots = 0;
-
             foreach (BotBase? bot in bots)
             {
                 if (bot == null)
@@ -92,15 +91,13 @@ namespace QuestingBots.Patches
                     convertedBots++;
                 }
 
-                UpdatedBots.Add(bot);
+                yield return bot;
             }
 
             if (convertedBots < targetCount)
             {
                 _loggingUtil.Warning($"{targetCount} player Scavs were requested, but only {convertedBots} were created");
             }
-
-            return UpdatedBots;
         }
 
         private static bool CanConvertToPScav(BotBase bot)

--- a/Shared/Config/config.json
+++ b/Shared/Config/config.json
@@ -33,7 +33,7 @@
 				"sleeping": 250
 			}
 		},
-		"quest_selection_timeout": 250,
+		"quest_selection_timeout": 20000,
 		"btr_run_distance": 10,
 		"allowed_bot_types_for_questing": {
 			"scav": false,

--- a/Shared/Config/config.json
+++ b/Shared/Config/config.json
@@ -20,20 +20,23 @@
 		"enabled": true,
 		"bot_pathing_update_interval_ms": 100,
 		"brain_layer_priorities": {
-			"with_sain" : {
+			"with_sain": {
 				"questing": 18,
 				"following": 19,
 				"regrouping": 26,
 				"sleeping": 250
 			},
-			"without_sain" : {
+			"without_sain": {
 				"questing": 21,
 				"following": 22,
 				"regrouping": 26,
 				"sleeping": 250
 			}
 		},
-		"quest_selection_timeout": 20000,
+		"quest_selection": {
+			"max_calc_time_per_frame_ms": 1,
+			"timeout": 20000
+		},
 		"btr_run_distance": 10,
 		"allowed_bot_types_for_questing": {
 			"scav": false,
@@ -48,14 +51,14 @@
 			"follower_break_time": 10,
 			"max_not_able_bodied_time": 120,
 			"stuck_bot_remedies": {
-				"enabled" : true,
+				"enabled": true,
 				"min_time_before_jumping": 6,
 				"jump_debounce_time": 4,
 				"min_time_before_vaulting": 8,
 				"vault_debounce_time": 4
 			}
 		},
-		"unlocking_doors" : {
+		"unlocking_doors": {
 			"enabled": {
 				"scav": false,
 				"pscav": false,
@@ -102,11 +105,11 @@
 			"min_health_legs": 50,
 			"max_overweight_percentage": 100,
 			"search_time_after_combat": {
-				"prioritized_sain" : {
+				"prioritized_sain": {
 					"min": 5,
 					"max": 20
 				},
-				"prioritized_questing" : {
+				"prioritized_questing": {
 					"min": 20,
 					"max": 45
 				}
@@ -188,11 +191,11 @@
 				"min": 0.1,
 				"max": 0.5
 			},
-			"sharp_path_corners" : {
+			"sharp_path_corners": {
 				"distance": 2,
 				"angle": 45
 			},
-			"approaching_closed_doors" : {
+			"approaching_closed_doors": {
 				"distance": 3,
 				"angle": 60
 			}
@@ -232,12 +235,12 @@
 				"chance_of_having_keys": 50,
 				"match_looting_behavior_distance": 5,
 				"level_range": [
-					[0, 99],
-					[1, 8],
-					[10, 15],
-					[20, 25],
-					[30, 30],
-					[40, 40]
+					[ 0, 99 ],
+					[ 1, 8 ],
+					[ 10, 15 ],
+					[ 20, 25 ],
+					[ 30, 30 ],
+					[ 40, 40 ]
 				]
 			},
 			"lightkeeper_island_quests": {

--- a/Shared/Configuration/QuestSelectionConfig.cs
+++ b/Shared/Configuration/QuestSelectionConfig.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace QuestingBots.Configuration
+{
+    [DataContract]
+    public class QuestSelectionConfig
+    {
+        [DataMember(Name = "max_calc_time_per_frame_ms", IsRequired = true)]
+        public float MaxCalcTimePerFrame { get; set; } = 1;
+
+        [DataMember(Name = "timeout", IsRequired = true)]
+        public float Timeout { get; set; } = 20000;
+
+        public QuestSelectionConfig()
+        {
+
+        }
+    }
+}

--- a/Shared/Configuration/QuestingConfig.cs
+++ b/Shared/Configuration/QuestingConfig.cs
@@ -20,7 +20,7 @@ namespace QuestingBots.Configuration
         public BrainLayerPrioritiesOptionsConfig BrainLayerPriorities { get; set; } = new BrainLayerPrioritiesOptionsConfig();
 
         [DataMember(Name = "quest_selection_timeout", IsRequired = true)]
-        public float QuestSelectionTimeout { get; set; } = 2000;
+        public float QuestSelectionTimeout { get; set; } = 20000;
 
         [DataMember(Name = "btr_run_distance", IsRequired = true)]
         public float BTRRunDistance { get; set; } = 40;

--- a/Shared/Configuration/QuestingConfig.cs
+++ b/Shared/Configuration/QuestingConfig.cs
@@ -19,8 +19,8 @@ namespace QuestingBots.Configuration
         [DataMember (Name = "brain_layer_priorities", IsRequired = true)]
         public BrainLayerPrioritiesOptionsConfig BrainLayerPriorities { get; set; } = new BrainLayerPrioritiesOptionsConfig();
 
-        [DataMember(Name = "quest_selection_timeout", IsRequired = true)]
-        public float QuestSelectionTimeout { get; set; } = 20000;
+        [DataMember(Name = "quest_selection", IsRequired = true)]
+        public QuestSelectionConfig QuestSelection { get; set; } = new QuestSelectionConfig();
 
         [DataMember(Name = "btr_run_distance", IsRequired = true)]
         public float BTRRunDistance { get; set; } = 40;

--- a/Shared/Models/SerializableVector3.cs
+++ b/Shared/Models/SerializableVector3.cs
@@ -29,6 +29,10 @@ namespace QuestingBots.Models
             Z = z;
         }
 
+        public override string ToString() => $"(X={X},Y={Y},Z={Z})";
+
+        public bool HasNaNComponent() => Any(float.NaN);
+
         public bool Any(float n)
         {
             if (X.Equals(n)) return true;

--- a/Shared/QuestingBots-Shared.projitems
+++ b/Shared/QuestingBots-Shared.projitems
@@ -29,6 +29,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Configuration\LabyrinthQuestsConfig.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Configuration\PlayerScavBrainConversionChancesOverridesConfig.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Configuration\QuestSelectionConfig.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Configuration\ScavRaidSettingsConfig.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Configuration\ServerResponses\ServerErrorResponse.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Configuration\ServerResponses\TypedServerResponse.cs" />


### PR DESCRIPTION
* Spread work performed after a bot spawns over multiple frames
* Created quest-selection job system that spreads work out over multiple frames. Created new config entry for max time per frame.
* Reduced allocations in many functions
* Lots of refactoring
* **Bug fix for objective layer not being paused while bots unlock doors**
* Bug fix for bots not calculating the angle to their extraction point correctly when selecting a new quest